### PR TITLE
fix syntax highlight of gedit 2.28.4 on CentOS 6

### DIFF
--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -5040,7 +5040,7 @@ class RBPDF
     #Read whole file
     data='';
     open(file,'rb') do |f|
-      data<<f.read();
+      data << f.read()
     end
     return {'w' => a[0],'h' => a[1],'cs' => colspace,'bpc' => bpc,'f'=>'DCTDecode','data' => data}
   end


### PR DESCRIPTION
![1](https://cloud.githubusercontent.com/assets/200784/7216161/6fd512d8-e630-11e4-9961-c612f560d0b2.png)

![2](https://cloud.githubusercontent.com/assets/200784/7216162/7668e0c0-e630-11e4-8187-79d25f77220c.png)
