### PR TITLE
Upgrade to htmlentities 4.3.4

### DIFF
--- a/rbpdf.gemspec
+++ b/rbpdf.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "htmlentities", "= 4.3.1"
+  spec.add_runtime_dependency "htmlentities", "= 4.3.4"
   spec.add_runtime_dependency "rbpdf-font", "~> 1.19.0"
   spec.required_ruby_version = '>= 1.8.7'
 


### PR DESCRIPTION
fix warning message

```
/usr/local/lib/ruby/gems/2.2.0/gems/htmlentities-4.3.1/lib/htmlentitiesexpanded.rb:465: warning: duplicated key at line 466 ignored: "inodot"
[DEPRECATION] `last_comment` is deprecated.  Please use `last_descriptid.
```
