### PR TITLE
Use pessimistic instead of strict specifier

### DIFF
--- a/rbpdf.gemspec
+++ b/rbpdf.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "htmlentities", "= 4.3.1"
+  spec.add_runtime_dependency "htmlentities", "~> 4.3.1"
   spec.add_runtime_dependency "rbpdf-font", "~> 1.19.0"
   spec.required_ruby_version = '>= 1.8.7'
 


### PR DESCRIPTION
Fixes #29 and #33 in a slightly more flexible way than #35 