### PR TITLE
removes the unnecessary incrementation of the index of a new link

### DIFF
--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -2983,7 +2983,7 @@ class RBPDF
   #
   def AddLink()
     #Create a new internal link
-    n=@links.length+1;
+    n = @links.length
     @links[n]=[0,0];
     return n;
   end
@@ -3744,7 +3744,7 @@ class RBPDF
       if (@color_flag)
         s<<' Q';
       end
-      if link && ((link.is_a?(String) and !link.empty?) or (link.is_a?(Integer) and link != 0)) # Integer is PDF file Page No.
+      if link && ((link.is_a?(String) and !link.empty?) or (link.is_a?(Integer) and link >= 0)) # Integer is @links array index
         Link(xdx, y + ((h - @font_size) / 2.0), width, @font_size, link, ns)
       end
     end

--- a/test/rbpdf_html_anchor_test.rb
+++ b/test/rbpdf_html_anchor_test.rb
@@ -79,7 +79,7 @@ class RbpdfTest < Test::Unit::TestCase
     pdf.write_html(htmlcontent, true, 0, true, 0)
 
     pdf.send(:mapLinksToHtmlAnchors)
-    link_position = pdf.instance_variable_get(:@links)[1]
+    link_position = pdf.instance_variable_get(:@links)[0]
     assert_equal [3, 73.50124999999998], link_position
   end
 
@@ -98,7 +98,7 @@ class RbpdfTest < Test::Unit::TestCase
 
     pdf.send(:mapLinksToHtmlAnchors)
 
-    link_position = pdf.instance_variable_get(:@links)[1]
+    link_position = pdf.instance_variable_get(:@links)[0]
     assert_equal [1, 10.001249999999999], link_position
   end
 


### PR DESCRIPTION
Without this patch, the `@links` array looks like `[nil, [0, 0], nil, [0,0]]` after `add_link` has been called twice due to the incrementation of `n` done there.