### PR TITLE
freeze unicode tables

### DIFF
--- a/lib/unicode_data.rb
+++ b/lib/unicode_data.rb
@@ -1,4 +1,5 @@
 # coding: ASCII-8BIT
+# frozen_string_literal: true
 #============================================================+
 # File name   : unicode_data.rb
 # Begin       : 2008-01-01


### PR DESCRIPTION
Hi, unicode tables are loaded during boot. This patch reduces retained memory by sharing duplicated strings.

```
retained memory
before
   3275111  rbpdf-1.19.8
after
   2566462  rbpdf-1.19.8+
```