### PR TITLE
fix license warning

### DIFF
--- a/rbpdf.gemspec
+++ b/rbpdf.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{RBPDF via TCPDF.}
   spec.description   = %q{A template plugin allowing the inclusion of ERB-enabled RBPDF template files.}
   spec.homepage      = ""
-  spec.licenses      = ['MIT', 'LGPL 2.1 or later']
+  spec.licenses      = ['MIT', 'LGPL-2.1-or-later']
   spec.files         = Dir.glob("lib/rbpdf/version.rb") +
                        Dir.glob("lib/*.rb") +
                        Dir.glob("lib/core/rmagick.rb") +


### PR DESCRIPTION
```
WARNING:  license value 'LGPL 2.1 or later' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'LGPL-2.1', 'LGPL-2.1+'?
```