### PR TITLE
Proposal: Make the image file path acquisition process extensible

### DIFF
--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -49,7 +49,7 @@
 require "rbpdf/version"
 
 require 'htmlentities'
-require 'rbpdf-font' 
+require 'rbpdf-font'
 require 'erb'
 
 begin
@@ -11312,11 +11312,11 @@ protected
       while html_b =~ /<xre([^\>]*)>(.*?)\n(.*?)<\/pre>/mi
         # preserve newlines on <pre> tag
         html_b = html_b.gsub(/<xre([^\>]*)>(.*?)\n(.*?)<\/pre>/mi) do
-          if ($2 != '') and ($3 != '') 
+          if ($2 != '') and ($3 != '')
             "<xre#{$1}>#{$2}<br />#{$3}</pre>"
-          elsif ($2 == '') and ($3 != '') 
+          elsif ($2 == '') and ($3 != '')
             "<xre#{$1}>#{$3}</pre>"
-          elsif ($2 != '') and ($3 == '') 
+          elsif ($2 != '') and ($3 == '')
             "<xre#{$1}>#{$2}</pre>"
           else
             "<xre#{$1}></pre>"


### PR DESCRIPTION
I want you to change the image file path acquisition process using a temporary file to the method with a block argument.

rbpdf creates an image using the local image file path, or downloads the image file of the remote URL (http, https) to a local temporary file and then creates the image. However, you cannot create an image using the image data stored in the database.

Considering the case where you want to use unexpected image data, I think that the image file path acquisition process should be divided by the method.
Change the method name (`proc_image_file`) as appropriate.