### PR TITLE
Don't change an object while iterating over it

### DIFF
--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -10176,12 +10176,7 @@ public
         end
       end
       # remove marked characters
-      chardata2.each_with_index do |value, key|
-        if value[:char] == false
-          chardata2.delete_at(key)
-        end
-      end
-      chardata = chardata2
+      chardata = chardata2.reject {|value| value[:char] == false }
       numchars = chardata.size
       chardata2 = nil
       arabicarr = nil


### PR DESCRIPTION
The previous code was changing the `chardata2` array while iterating over it. After the first deletion the indexes in `key` are not aligned with the real array indexes anymore and all deletions after the first one were off.

We unfortunately cannot provide test data as we are not proficient in Arabic script and this was noticed with customer data. I hope it is clear enough what the original purpose of the code was and that the proposed change avoids the problem with the original code.