### PR TITLE
Don't pop if no bidi info pushed

### DIFF
--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -9768,7 +9768,7 @@ public
         end
       when @@k_pdf
         # X7. With each PDF, determine the matching embedding or override code. If there was a valid matching code, restore (pop) the last remembered (pushed) embedding level and directional override.
-        if remember.length
+        if remember.length > 0
           last = remember.length - 1
           case remember[last][:num]
           when @@k_rle, @@k_lre, @@k_rlo, @@k_lro


### PR DESCRIPTION
A dangling U+202C 'pop directional formatting' will
cause an error here if no other directional formatting
character had been encountered before as `remember`
is then empty