### PR TITLE
Suppresses output for Circle(), Ellipse(), PieSector(), and PieSectorXY() when the radius is 0.

### DIFF
--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -9131,6 +9131,8 @@ public
   # [@since 4.9.019 (2010-04-26)]
   #
   def outellipticalarc(xc, yc, rx, ry, xang=0, angs=0, angf=360, pie=false, nc=2)
+    return if rx == 0 && ry == 0
+
     k = @k
     if nc < 2
       nc = 2

--- a/test/rbpdf_content_test.rb
+++ b/test/rbpdf_content_test.rb
@@ -118,6 +118,21 @@ class RbpdfPageTest < Test::Unit::TestCase
     assert_equal 'S'                                          , content[14]
   end
 
+  test "circle content radius=0 (no circle output)" do
+    pdf = MYPDF.new
+
+    pdf.set_print_header(false)
+    pdf.add_page
+    pdf.circle(100, 200, 0)
+
+    content = []
+    contents = pdf.getPageBuffer(1)
+    contents.each_line {|line| content.push line.chomp }
+
+    assert_equal 5, content.length
+    assert_equal 'S'                                          , content[4]
+  end
+
   test "write content test" do
     pdf = MYPDF.new
     pdf.add_page()


### PR DESCRIPTION
Suppresses output for Circle(), Ellipse(), PieSector(), and PieSectorXY() when the radius is 0.