### PR TITLE
ToUnicode Identity-H name was replaced with a full CMap (to avoid www.pdf-online.com PDF/A Validation error).

### DIFF
--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -7244,11 +7244,18 @@ protected
     out << ' /BaseFont /' + fontname + ''
     out << ' /Name /F' + font['i'].to_s
     out << ' /Encoding /' + font['enc']
-    out << ' /ToUnicode /Identity-H'
-    out << ' /DescendantFonts [' + (@n + 1).to_s + ' 0 R]'
+    out << " /ToUnicode #{@n + 1} 0 R"
+    out << " /DescendantFonts [#{@n + 2} 0 R]"
     out << ' >>'
     out << ' endobj'
     out(out)
+
+    # ToUnicode Object
+    newobj()
+    filter = @compress ? '/Filter /FlateDecode ' : ''
+    stream = @compress ? Zlib::Deflate.deflate(@@cmap_identity_h) : @@cmap_identity_h
+    stream = getrawstream(stream)
+    out("<<#{filter}/Length #{stream.length}>> stream\n#{stream}\nendstream\nendobj")
 
     # CIDFontType2
     # A CIDFont whose glyph descriptions are based on TrueType font technology
@@ -8080,18 +8087,27 @@ protected
   end
 
   #
+  # get raw output stream.
+  # @param string :s string to output.
+  # @param int :n object reference for encryption mode
+  # @access protected
+  #
+  def getrawstream(s, n=0)
+    if n <= 0
+      # default to current object
+      n = @n
+    end
+    encrypt_data(n, s)
+  end
+
+  #
   # Format output stream
   # @param string :s string to output.
   # @param int :n object reference for encryption mode
   # @access protected
   #
   def getstream(s, n=0)
-    if n <= 0
-      # default to current object
-      n = @n
-    end
-    s = encrypt_data(n, s)
-    return "stream\n" + s + "\nendstream"
+    "stream\n" + getrawstream(s, n=0) + "\nendstream"
   end
 
   #

--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -7244,6 +7244,7 @@ protected
     out << ' /BaseFont /' + fontname + ''
     out << ' /Name /F' + font['i'].to_s
     out << ' /Encoding /' + font['enc']
+    out << ' /ToUnicode /Identity-H'
     out << ' /DescendantFonts [' + (@n + 1).to_s + ' 0 R]'
     out << ' >>'
     out << ' endobj'

--- a/lib/unicode_data.rb
+++ b/lib/unicode_data.rb
@@ -18326,6 +18326,35 @@ module Unicode_data
 382=>158   # zcaron2
 }
 
+#
+# ToUnicode map for Identity-H
+#   CMapType : 1 = Convert to CID, 2 = Convert to Unicode
+#
+@@cmap_identity_h = <<-CMap
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+/CIDSystemInfo <<
+  /Registry (Adobe)
+  /Ordering (UCS)
+  /Supplement 0
+>> def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+
+1 beginbfrange
+<0000> <ffff> <0000>
+endbfrange
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+CMap
+
 end
 
 #============================================================+


### PR DESCRIPTION
fix: Incorrect characters when copying out of a generated PDF with Unicode fonts. (fix https://github.com/naitoh/rbpdf/issues/65)
Added CMap table of CMapType=2 (Convert to Unicode) for Unicode Font.
    
## [Why]
https://www.pdf-online.com/osa/validate.aspx
    
* Result
```
Document does not conform to PDF/A.
```
    
* Details
```
Validating file "example001.pdf" for conformance level pdf1.7
  The value of the key ToUnicode must not be of type name.
  The document does not conform to the requested standard.
The document doesn't conform to the PDF reference (missing required entries, wrong value types, etc.).
The document does not conform to the PDF 1.7 standard.
Done.
```