### PR TITLE
Fixed an infinite loop issue and an x-positioning issue with li tags.

### DIFF
--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -12919,7 +12919,7 @@ public
           end
         end
         # text
-        @htmlvspace = 0
+        @htmlvspace = 0 unless dom[key]['value'].strip.length == 0
         if !@premode and isRTLTextDir()
           # reverse spaces order
           len1 = dom[key]['value'].length

--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -12900,7 +12900,7 @@ public
             startlinepage = @page
           end
         end
-      elsif dom[key]['value'].strip.length > 0
+      elsif dom[key]['value'].length > 0
         # print list-item
         if !empty_string(@lispacer)
           SetFont(pfontname, pfontstyle, pfontsize)

--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -12186,19 +12186,12 @@ public
           autolinebreak = false
           if dom[key]['width'] and (dom[key]['width'].to_i > 0)
             imgw = getHTMLUnitToUnits(dom[key]['width'], 1, 'px', false)
-            if cell
-              cellmargin = @c_margin
-            else
-              cellmargin = 0
-            end
-            if (@rtl and (@x - imgw < @l_margin + cellmargin)) or (!@rtl and (@x + imgw > @w - @r_margin - cellmargin))
-              # add automatic line break only if we can grow up the width
-              unless ((@rtl and (@x == @w - @r_margin - cellmargin)) or (!@rtl and (@x == @l_margin + cellmargin)))
-                autolinebreak = true
-                Ln('', cell)
-                # go back to evaluate this line break
-                key -= 1
-              end
+            if (@rtl and (@x - imgw < @l_margin + @c_margin)) or (!@rtl and (@x + imgw > @w - @r_margin - @c_margin))
+              # add automatic line break
+              autolinebreak = true
+              Ln('', cell)
+              # go back to evaluate this line break
+              key -= 1
             end
           end
           if !autolinebreak

--- a/test/rbpdf_html_test.rb
+++ b/test/rbpdf_html_test.rb
@@ -582,6 +582,29 @@ class RbpdfHtmlTest < Test::Unit::TestCase
     assert_equal 'a\\\\bc', pdf_text
   end
 
+  test "write_html <ol><li> tag test" do
+    pdf = MYPDF.new
+    pdf.set_print_header(false)
+    pdf.add_page()
+
+    htmlcontent = '<ol><li>text A</li><li>text B</li></ol>'
+    pdf.write_html(htmlcontent, true, 0, true, 0)
+    pdf_text = pdf.get_html_text(1)
+    assert_equal '1.text A2.text B', pdf_text
+  end
+
+  test "write_html <ol><li> tag with image tag test" do
+    pdf = MYPDF.new
+    pdf.set_print_header(false)
+    pdf.add_page()
+
+    img_file = File.join(File.dirname(__FILE__), 'logo_rbpdf_8bit.png')
+    htmlcontent = "<ol><img src='#{img_file}' width='30' height='30' border='0' /><li>text A</li><li>text B</li></ol>"
+    pdf.write_html(htmlcontent, true, 0, true, 0)
+    pdf_text = pdf.get_html_text(1)
+    assert_equal ' 1.text A2.text B', pdf_text # A space is placed before the img tag.
+  end
+
   test "write_html Character Entities test" do
     pdf = MYPDF.new
     pdf.set_print_header(false)

--- a/test/rbpdf_htmlcell_test.rb
+++ b/test/rbpdf_htmlcell_test.rb
@@ -12,7 +12,11 @@ class RbpdfTest < Test::Unit::TestCase
                                     :border => 0,      :pno => 2, :no => 2},
     'Page Break border'         => {:html => '<p>foo</p>', :margin => 30,
                                     :border => 'LRBT', :pno => 2, :no => 2},
-    'pre tag y position'        => {:html => "<p>test 0</p>\n <pre>test 1\ntest 2\ntest 3</pre>\n <p>test 10</p>", :line => 7,
+    'Y position when there is no space between pre and p tags' =>
+                                   {:html => "<p>test 0</p>\n <pre>test 1\ntest 2\ntest 3</pre><p>test 10</p>", :line => 7,
+                                    :border => 0,      :pno => 1, :no => 1},
+    'Y position when there is a space between pre and p tags' =>
+                                   {:html => "<p>test 0</p>\n <pre>test 1\ntest 2\ntest 3</pre>\n <p>test 10</p>", :line => 7,
                                     :border => 0,      :pno => 1, :no => 1},
   }
 

--- a/test/rbpdf_image_test.rb
+++ b/test/rbpdf_image_test.rb
@@ -190,17 +190,15 @@ class RbpdfTest < Test::Unit::TestCase
     return if Object.const_defined?(:Magick) or Object.const_defined?(:MiniMagick)
 
     image_sizes = [
+      # writeHTML() : not !@rtl and (@x + imgw > @w - @r_margin - @c_margin) case
       {'width' => 10,  'height' => 20, 'cell' => false},
       {'width' => 100, 'height' => 100, 'cell' => false},
       {'width' => 100, 'height' => 100, 'cell' => true},
       {'width' => 500, 'height' => 100, 'cell' => false},
-      # writeHTML() : !@rtl and (@x + imgw > @w - @r_margin - cellmargin), !@rtl and (@x == @l_margin + cellmargin) case
+      # writeHTML() : !@rtl and (@x + imgw > @w - @r_margin - @c_margin) case
       {'width' => 600, 'height' => 10, 'cell' => false},
       {'width' => 600, 'height' => 10, 'cell' => true},
       {'width' => 600, 'height' => 13, 'cell' => false},
-      # writeHTML() : !@rtl and (@x + imgw > @w - @r_margin - cellmargin), !@rtl and (@x != @l_margin + cellmargin) case
-      {'width' => 600, 'height' => 10, 'cell' => false, 'l_margin' => 1.0},
-      {'width' => 600, 'height' => 10, 'cell' => true, 'l_margin' => 1.0},
     ]
 
     img_file = File.join(File.dirname(__FILE__), 'logo_rbpdf_8bit.png')
@@ -209,12 +207,7 @@ class RbpdfTest < Test::Unit::TestCase
       pdf.add_page
       htmlcontent = "<body><img src='#{img_file}' width='#{size['width']}' height='#{size['height']}'/></body>"
 
-      unless size['l_margin'].nil?
-        pdf.set_left_margin(size['l_margin'])
-        x_org = size['l_margin']
-      else
-        x_org = pdf.get_x
-      end
+      x_org = pdf.get_x
       y_org = pdf.get_y
 
       imgw = pdf.getHTMLUnitToUnits(size['width'])
@@ -223,17 +216,15 @@ class RbpdfTest < Test::Unit::TestCase
       x = pdf.get_x
       y = pdf.get_y
       w = pdf.get_page_width
-      l_margin = pdf.instance_variable_get("@l_margin")
       r_margin = pdf.instance_variable_get("@r_margin")
       lasth = pdf.get_font_size * pdf.get_cell_height_ratio
       if x + imgw > w - r_margin
-        result = lasth
-        result += lasth unless size['l_margin'].nil?
+        result = lasth * 2
       else
         result = lasth + imgh - pdf.get_font_size_pt / pdf.get_scale_factor
       end
 
-      test_name = "[ width: #{size['width']} height: #{size['height']} cell: #{size['cell']} l_margin: #{size['l_margin']}]:"
+      test_name = "[ width: #{size['width']} height: #{size['height']} cell: #{size['cell']}]:"
       assert_equal test_name + x_org.to_s, test_name + x.to_s
       assert_equal test_name + (y_org + result).round(2).to_s, test_name + y.round(2).to_s
     }


### PR DESCRIPTION
This was caused by a correction error in af992f069233c6af449909a4dd0bd79f72338607.

## Infinite loop has been resolved.

This problem was not properly corrected in https://github.com/naitoh/rbpdf/pull/68.

### [Original process in rbpdf 1.19.5]
    
1. A space is placed before the img tag.
    https://github.com/naitoh/rbpdf/blob/fb224a16792363505026b4b5439fea58965039e8/lib/rbpdf.rb#L11262
2. This space is stripped and emptied by the DOM process in writeHTML.
    https://github.com/naitoh/rbpdf/blob/fb224a16792363505026b4b5439fea58965039e8/lib/rbpdf.rb#L12797-L12839
3. This loop process sets key -=1 and @newline=true. (by [Ln()](https://github.com/naitoh/rbpdf/blob/fb224a16792363505026b4b5439fea58965039e8/lib/rbpdf.rb#L5327-L5347))
    https://github.com/naitoh/rbpdf/blob/fb224a16792363505026b4b5439fea58965039e8/lib/rbpdf.rb#L12076-L12088
4. Since dom[key-1]['value'] is empty because it has already been stripped, it is not entered in this process and @newline remains true.
    https://github.com/naitoh/rbpdf/blob/fb224a16792363505026b4b5439fea58965039e8/lib/rbpdf.rb#L12247-L12544
5. Because @newline=true, it does not enter the process of 3.

### [Wrong process af992f069233c6af449909a4dd0bd79f7272338607]

Since process 2 could no longer be executed, @newline=false was used in 4, resulting in an infinite loop.

##  Fixed a bug that caused the x position to shift when an `<img>` tag was behind a `<li>` tag in HTML.
