### PR TITLE
Avoid rdoc `stack level too deep (SystemStackError)` in gem install.

### DIFF
--- a/rbpdf.gemspec
+++ b/rbpdf.gemspec
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright (c) 2011-2019 NAITOH Jun
+# Copyright (c) 2011-2023 NAITOH Jun
 # Released under the MIT license
 # http://www.opensource.org/licenses/MIT
 
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                        ["Rakefile", "rbpdf.gemspec", "Gemfile",
                         "CHANGELOG", "test_unicode.rbpdf", "README.md", "LICENSE.TXT", "MIT-LICENSE",
                         "utf8test.txt", "logo_example.png" ]
-  spec.rdoc_options  += [ '--exclude', 'lib/fonts/',
+  spec.rdoc_options  += [ '--exclude', 'lib/core/mini_magick.rb',
                           '--exclude', 'lib/htmlcolors.rb',
                           '--exclude', 'lib/unicode_data.rb' ]
 


### PR DESCRIPTION
```
$ rake build && gem uninstall rbpdf && gem install --local pkg/rbpdf-1.20.1.gem
rbpdf 1.20.1 built to pkg/rbpdf-1.20.1.gem.
Successfully uninstalled rbpdf-1.20.1
Successfully installed rbpdf-1.20.1
Parsing documentation for rbpdf-1.20.1
Installing ri documentation for rbpdf-1.20.1
/Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rdoc/method_attr.rb:122:in `==': stack level too deep (SystemStackError)
	from /Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rdoc/method_attr.rb:153:in `see'
	from /Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rdoc/method_attr.rb:135:in `documented?'
	from /Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rdoc/method_attr.rb:135:in `documented?'
	from /Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rdoc/method_attr.rb:135:in `documented?'
	from /Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rdoc/method_attr.rb:135:in `documented?'
	from /Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rdoc/method_attr.rb:135:in `documented?'
	from /Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rdoc/method_attr.rb:135:in `documented?'
	from /Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rdoc/method_attr.rb:135:in `documented?'
	 ... 11891 levels...
	from /Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rubygems/command_manager.rb:178:in `process_args'
	from /Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rubygems/command_manager.rb:148:in `run'
	from /Users/naitoh/.rbenv/versions/2.6.10/lib/ruby/2.6.0/rubygems/gem_runner.rb:59:in `run'
	from /Users/naitoh/.rbenv/versions/2.6.10/bin/gem:21:in `<main>'
```