### PR TITLE
Reduce CI test patterns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,48 +10,33 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['jruby', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
-        gemfile: ['Gemfile.rails5', 'Gemfile.rails5_rmagick', 'Gemfile.rails5_mini_magick',
-                  'Gemfile.rails6', 'Gemfile.rails6_rmagick', 'Gemfile.rails6_mini_magick',
-                  'Gemfile.rails7', 'Gemfile.rails7_rmagick', 'Gemfile.rails7_mini_magick',
-                  'Gemfile.rbpdf-font']
-        exclude:
-          - { ruby: 'jruby', gemfile: 'Gemfile.rails5' }
-          - { ruby: 'jruby', gemfile: 'Gemfile.rails5_rmagick' }
-          - { ruby: 'jruby', gemfile: 'Gemfile.rails5_mini_magick' }
-          - { ruby: 'jruby', gemfile: 'Gemfile.rails6_rmagick' }
-          - { ruby: 'jruby', gemfile: 'Gemfile.rails6_mini_magick' }
-          - { ruby: 'jruby', gemfile: 'Gemfile.rails7_rmagick' }
-          - { ruby: 'jruby', gemfile: 'Gemfile.rails7_mini_magick' }
-          - { ruby: '2.3', gemfile: 'Gemfile.rails6' }
-          - { ruby: '2.3', gemfile: 'Gemfile.rails6_rmagick' }
-          - { ruby: '2.3', gemfile: 'Gemfile.rails6_mini_magick' }
-          - { ruby: '2.3', gemfile: 'Gemfile.rails7' }
-          - { ruby: '2.3', gemfile: 'Gemfile.rails7_rmagick' }
-          - { ruby: '2.3', gemfile: 'Gemfile.rails7_mini_magick' }
-          - { ruby: '2.4', gemfile: 'Gemfile.rails6' }
-          - { ruby: '2.4', gemfile: 'Gemfile.rails6_rmagick' }
-          - { ruby: '2.4', gemfile: 'Gemfile.rails6_mini_magick' }
-          - { ruby: '2.4', gemfile: 'Gemfile.rails7' }
-          - { ruby: '2.4', gemfile: 'Gemfile.rails7_rmagick' }
-          - { ruby: '2.4', gemfile: 'Gemfile.rails7_mini_magick' }
-          - { ruby: '2.5', gemfile: 'Gemfile.rails7' }
-          - { ruby: '2.5', gemfile: 'Gemfile.rails7_rmagick' }
-          - { ruby: '2.5', gemfile: 'Gemfile.rails7_mini_magick' }
-          - { ruby: '2.6', gemfile: 'Gemfile.rails7' }
-          - { ruby: '2.6', gemfile: 'Gemfile.rails7_rmagick' }
-          - { ruby: '2.6', gemfile: 'Gemfile.rails7_mini_magick' }
-          - { ruby: '3.0', gemfile: 'Gemfile.rails5' }
-          - { ruby: '3.0', gemfile: 'Gemfile.rails5_rmagick' }
-          - { ruby: '3.0', gemfile: 'Gemfile.rails5_mini_magick' }
-          - { ruby: '3.1', gemfile: 'Gemfile.rails5' }
-          - { ruby: '3.1', gemfile: 'Gemfile.rails5_rmagick' }
-          - { ruby: '3.1', gemfile: 'Gemfile.rails5_mini_magick' }
-          - { ruby: '3.2', gemfile: 'Gemfile.rails5' }
-          - { ruby: '3.2', gemfile: 'Gemfile.rails5_rmagick' }
-          - { ruby: '3.2', gemfile: 'Gemfile.rails5_mini_magick' }
-          - { ruby: '3.2', gemfile: 'Gemfile.rails6' }
-          - { ruby: '3.2', gemfile: 'Gemfile.rails6_rmagick' }
-          - { ruby: '3.2', gemfile: 'Gemfile.rails6_mini_magick' }
+        gemfile: ['Gemfile.rbpdf-font']
+        include:
+          - { ruby: 'jruby', gemfile: 'Gemfile.rails7' }
+          - { ruby: '2.3', gemfile: 'Gemfile.rails5' }
+          - { ruby: '2.3', gemfile: 'Gemfile.rails5_rmagick' }
+          - { ruby: '2.3', gemfile: 'Gemfile.rails5_mini_magick' }
+          - { ruby: '2.4', gemfile: 'Gemfile.rails5' }
+          - { ruby: '2.4', gemfile: 'Gemfile.rails5_rmagick' }
+          - { ruby: '2.4', gemfile: 'Gemfile.rails5_mini_magick' }
+          - { ruby: '2.5', gemfile: 'Gemfile.rails6' }
+          - { ruby: '2.5', gemfile: 'Gemfile.rails6_rmagick' }
+          - { ruby: '2.5', gemfile: 'Gemfile.rails6_mini_magick' }
+          - { ruby: '2.6', gemfile: 'Gemfile.rails6' }
+          - { ruby: '2.6', gemfile: 'Gemfile.rails6_rmagick' }
+          - { ruby: '2.6', gemfile: 'Gemfile.rails6_mini_magick' }
+          - { ruby: '2.7', gemfile: 'Gemfile.rails7' }
+          - { ruby: '2.7', gemfile: 'Gemfile.rails7_rmagick' }
+          - { ruby: '2.7', gemfile: 'Gemfile.rails7_mini_magick' }
+          - { ruby: '3.0', gemfile: 'Gemfile.rails7' }
+          - { ruby: '3.0', gemfile: 'Gemfile.rails7_rmagick' }
+          - { ruby: '3.0', gemfile: 'Gemfile.rails7_mini_magick' }
+          - { ruby: '3.1', gemfile: 'Gemfile.rails7' }
+          - { ruby: '3.1', gemfile: 'Gemfile.rails7_rmagick' }
+          - { ruby: '3.1', gemfile: 'Gemfile.rails7_mini_magick' }
+          - { ruby: '3.2', gemfile: 'Gemfile.rails7' }
+          - { ruby: '3.2', gemfile: 'Gemfile.rails7_rmagick' }
+          - { ruby: '3.2', gemfile: 'Gemfile.rails7_mini_magick' }
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     name: Ruby ${{ matrix.ruby }}, ${{ matrix.gemfile }}


### PR DESCRIPTION
## [Why]

Reduce CI execution time by removing unnecessary test patterns.

- JRuby 9.4.x targets Ruby 3.1 compatibility.