### PR TITLE
Improved compatibility with ImageMagick 7.1.1-0 and later when using mini_magick.

### DIFF
--- a/lib/core/mini_magick.rb
+++ b/lib/core/mini_magick.rb
@@ -81,7 +81,7 @@ module Rbpdf
     
     # This needs work to cover more situations
     # I can't see how to just list the number of channels with ImageMagick / mini_magick
-    case image["%[channels]"].downcase
+    case image["%[channels]"].downcase.split.first
     when 'cmyk'
       out['channels'] = 4
     when 'rgb', 'rgba', 'srgb', 'srgba'  # Mac OS X : sRGB

--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -5171,11 +5171,11 @@ class RBPDF
       img = MiniMagick::Image.open(file)
       img.format 'png'
       if delete_alpha
-        if ['rgba', 'srgba', 'graya'].include?(img["%[channels]"].downcase)
+        if ['rgba', 'srgba', 'graya'].include?(img["%[channels]"].downcase.split.first)
           img.combine_options do |mogrify|
               mogrify.alpha 'off'
           end
-          if ['rgba', 'srgba', 'graya'].include?(img["%[channels]"].downcase)
+          if ['rgba', 'srgba', 'graya'].include?(img["%[channels]"].downcase.split.first)
             return false
           end
         end
@@ -5321,7 +5321,7 @@ class RBPDF
 
       img = MiniMagick::Image.open(file)
       img.format('png')
-      if ['rgba', 'srgba', 'graya'].include?(img["%[channels]"].downcase)
+      if ['rgba', 'srgba', 'graya'].include?(img["%[channels]"].downcase.split.first)
         img.combine_options do |mogrify|
           mogrify.channel 'matte'
           mogrify.separate '+matte'


### PR DESCRIPTION
### [Why]

ImageMagick 7.1.1-0 has extended the "%[channels]" response, which has caused compatibility issues.

https://github.com/ImageMagick/Website/blob/55cd1ffec57032f6442805a94842e60d1c1ea600/ChangeLog.md#711-0---2023-03-08
> return total channels and meta channels
See: https://github.com/ImageMagick/ImageMagick/commit/8abb43486dffc115b4e07ddef16296cc25e72d82

- ImageMagick 7.1.1-0 before
```
$ magick test/png_test_alpha.png -print "%[channels]\n" null:
srgba
```
```
irb> require 'mini_magick'
irb> image = MiniMagick::Image.open(File.join("./test/png_test_alpha.png"))
irb> image["%[channels]"]
=> "srgba"
```

- ImageMagick 7.1.1-0 and later
```
$ magick test/png_test_alpha.png -print "%[channels]\n" null:
srgba 4.0
```
```
irb> require 'mini_magick'
irb> image = MiniMagick::Image.open(File.join("./test/png_test_alpha.png"))
irb> image["%[channels]"]
=> "srgba 4.0"
```