### PR TITLE
Javascript Form & XHTML Form support

### DIFF
--- a/example/rails/app/controllers/example014_controller.rb
+++ b/example/rails/app/controllers/example014_controller.rb
@@ -1,0 +1,170 @@
+# coding: UTF-8
+#============================================================+
+# Begin       : 2008-03-04
+# Last Update : 2010-06-02
+#
+# Description : Example 014 for RBPDF class
+#               Javascript Form and user rights (only works on Adobe Acrobat)
+#
+# Author: Jun NAITOH
+# License: LGPL 2.1 or later
+#============================================================+
+
+require("example_common.rb")
+
+class Example014Controller < ApplicationController
+  def index
+    # create new PDF document
+    pdf = RBPDF.new(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false)
+
+    # set document information
+    pdf.set_creator(PDF_CREATOR)
+    pdf.set_author(PDF_AUTHOR)
+    pdf.set_title('RBPDF Example 014')
+    pdf.set_subject('RBPDF Tutorial')
+    pdf.set_keywords('RBPDF, PDF, example, test, guide')
+
+    # set default header data
+    pdf.set_header_data(PDF_HEADER_LOGO, PDF_HEADER_LOGO_WIDTH, PDF_HEADER_TITLE + ' 014', PDF_HEADER_STRING)
+
+    # set header and footer fonts
+    pdf.set_header_font([PDF_FONT_NAME_MAIN, '', PDF_FONT_SIZE_MAIN])
+    pdf.set_footer_font([PDF_FONT_NAME_DATA, '', PDF_FONT_SIZE_DATA])
+
+    # set default monospaced font
+    pdf.set_default_monospaced_font(PDF_FONT_MONOSPACED)
+
+    # set margins
+    pdf.set_margins(PDF_MARGIN_LEFT, PDF_MARGIN_TOP, PDF_MARGIN_RIGHT)
+    pdf.set_header_margin(PDF_MARGIN_HEADER)
+    pdf.set_footer_margin(PDF_MARGIN_FOOTER)
+
+    # set auto page breaks
+    pdf.set_auto_page_break(true, PDF_MARGIN_BOTTOM)
+
+    # set image scale factor
+    pdf.set_image_scale(PDF_IMAGE_SCALE_RATIO)
+
+    # set some language-dependent strings
+    pdf.set_language_array($l)
+
+    # ---------------------------------------------------------
+
+    # set font
+    # IMPORTANT: disable font subsetting to allow users editing the document
+    pdf.set_font('helvetica', '', 10)
+
+    # add a page
+    pdf.add_page()
+
+    # It is possible to create text fields, combo boxes, check boxes and buttons.
+    # Fields are created at the current position and are given a name.
+    # This name allows to manipulate them via JavaScript in order to perform some validation for instance.
+
+    # set default form properties
+    pdf.setFormDefaultProp({'lineWidth'=>1, 'borderStyle'=>'solid', 'fillColor'=>[255, 255, 200], 'strokeColor'=>[255, 128, 128]})
+
+    pdf.set_font('helvetica', 'BI', 18)
+    pdf.cell(0, 5, 'Example of Form', 0, 1, 'C')
+    pdf.ln(10)
+
+    pdf.set_font('helvetica', '', 12)
+
+    # First name
+    pdf.cell(35, 5, 'First name:')
+    pdf.text_field('firstname', 50, 5)
+    pdf.ln(6)
+
+    # Last name
+    pdf.cell(35, 5, 'Last name:')
+    pdf.text_field('lastname', 50, 5)
+    pdf.ln(6)
+
+    # Gender
+    pdf.cell(35, 5, 'Gender:')
+    pdf.combo_box('gender', 30, 5, [['', '-'], ['M', 'Male'],['F', 'Female']])
+    pdf.ln(6)
+
+    # Drink
+    pdf.cell(35, 5, 'Drink:')
+    pdf.radio_button('drink', 5, {}, {}, 'Water')
+    pdf.cell(35, 5, 'Water')
+    pdf.ln(6)
+    pdf.cell(35, 5, '')
+    pdf.radio_button('drink', 5, {}, {}, 'Beer', true)
+    pdf.cell(35, 5, 'Beer')
+    pdf.ln(6)
+    pdf.cell(35, 5, '')
+    pdf.radio_button('drink', 5, {}, {}, 'Wine')
+    pdf.cell(35, 5, 'Wine')
+    pdf.ln(10)
+
+    # Listbox
+    pdf.cell(35, 5, 'List:')
+    pdf.list_box('listbox', 60, 15, ['', 'item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7'], {'multipleSelection'=>'true'})
+    pdf.ln(20)
+
+    # Adress
+    pdf.cell(35, 5, 'Address:')
+    pdf.text_field('address', 60, 18, {'multiline'=>true})
+    pdf.ln(19)
+
+    # E-mail
+    pdf.cell(35, 5, 'E-mail:')
+    pdf.text_field('email', 50, 5)
+    pdf.ln(6)
+
+    # Newsletter
+    pdf.cell(35, 5, 'Newsletter:')
+    pdf.check_box('newsletter', 5, true, {}, {}, 'OK')
+    pdf.ln(10)
+
+    # Date of the day
+    pdf.cell(35, 5, 'Date:')
+    pdf.text_field('date', 30, 5, {}, {'v' => Date.today.to_s, 'dv' => Date.today.to_s})
+    pdf.ln(10)
+
+    pdf.SetX(50)
+
+    # button to validate and print
+    pdf.button('print', 30, 10, 'Print', 'Print()', {'lineWidth'=>2, 'borderStyle'=>'beveled', 'fillColor'=>[128, 196, 255], 'strokeColor'=>[64, 64, 64]})
+
+    # Reset button
+    pdf.button('reset', 30, 10, 'Reset', {'S'=>'ResetForm'}, {'lineWidth'=>2, 'borderStyle'=>'beveled', 'fillColor'=>[128, 196, 255], 'strokeColor'=>[64, 64, 64]})
+
+    # Submit button
+    pdf.button('submit', 30, 10, 'Submit', {'S'=>'SubmitForm', 'F'=>'http://localhost/printvars.php', 'Flags'=>['ExportFormat']}, {'lineWidth'=>2, 'borderStyle'=>'beveled', 'fillColor'=>[128, 196, 255], 'strokeColor'=>[64, 64, 64]})
+
+    # Form validation functions
+    js = <<~EOD
+    function CheckField(name,message) {
+      var f = getField(name)
+      if(f.value == '') {
+          app.alert(message)
+          f.setFocus()
+          return false
+      }
+      return true
+    }
+    function Print() {
+      if(!CheckField('firstname','First name is mandatory')) {return;}
+      if(!CheckField('lastname','Last name is mandatory')) {return;}
+      if(!CheckField('gender','Gender is mandatory')) {return;}
+      if(!CheckField('address','Address is mandatory')) {return;}
+      print()
+    }
+    EOD
+
+    # Add Javascript code
+    pdf.IncludeJS(js)
+
+    # ---------------------------------------------------------
+
+    # Close and output PDF document
+    send_data pdf.output(), :type => "application/pdf", :disposition => "inline"
+  end
+end
+
+#============================================================+
+# END OF FILE
+#============================================================+

--- a/example/rails/app/controllers/example054_controller.rb
+++ b/example/rails/app/controllers/example054_controller.rb
@@ -1,0 +1,112 @@
+# coding: UTF-8
+#============================================================+
+# Begin       : 2009-09-07
+# Last Update : 2010-06-02
+#
+# Description : Example 054 for TCPDF class
+#               XHTML Forms
+#
+# Author: Jun NAITOH
+# License: LGPL 2.1 or later
+#============================================================+
+
+require("example_common.rb")
+
+class Example054Controller < ApplicationController
+  def index
+    # create new PDF document
+    pdf = RBPDF.new(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false)
+
+    # set document information
+    pdf.set_creator(PDF_CREATOR)
+    pdf.set_author(PDF_AUTHOR)
+    pdf.set_title('RBPDF Example 054')
+    pdf.set_subject('RBPDF Tutorial')
+    pdf.set_keywords('RBPDF, PDF, example, test, guide')
+
+    # set default header data
+    pdf.set_header_data(PDF_HEADER_LOGO, PDF_HEADER_LOGO_WIDTH, PDF_HEADER_TITLE + ' 054', PDF_HEADER_STRING)
+
+    # set header and footer fonts
+    pdf.set_header_font([PDF_FONT_NAME_MAIN, '', PDF_FONT_SIZE_MAIN])
+    pdf.set_header_font([PDF_FONT_NAME_MAIN, '', PDF_FONT_SIZE_DATA])
+
+    # set default monospaced font
+    pdf.set_default_monospaced_font(PDF_FONT_MONOSPACED)
+
+    # set margins
+    pdf.set_margins(PDF_MARGIN_LEFT, PDF_MARGIN_TOP, PDF_MARGIN_RIGHT)
+    pdf.set_header_margin(PDF_MARGIN_HEADER)
+    pdf.set_footer_margin(PDF_MARGIN_FOOTER)
+
+    # set auto page breaks
+    pdf.set_auto_page_break(true, PDF_MARGIN_BOTTOM)
+
+    # set image scale factor
+    pdf.set_image_scale(PDF_IMAGE_SCALE_RATIO)
+
+    # set some language-dependent strings
+    pdf.set_language_array($l)
+
+    # ---------------------------------------------------------
+
+    # set font
+    # IMPORTANT: disable font subsetting to allow users editing the document
+    pdf.set_font('helvetica', '', 10)
+
+    # add a page
+    pdf.add_page()
+
+    # create some HTML content
+    html = <<~EOD
+    <h1>XHTML Form Example</h1>
+    <form method="post" action="http://localhost/printvars" enctype="multipart/form-data">
+    <label for="name">name:</label> <input type="text" name="name" value="test@example.net" size="20" maxlength="30" /><br />
+    <label for="password">password:</label> <input type="password" name="password" value="" size="20" maxlength="30" /><br /><br />
+    <label for="infile">file:</label> <input type="file" name="userfile" size="20" /><br /><br />
+    <input type="checkbox" name="agree" value="1" checked="checked"/> <label for="agree">I agree </label><br /><br />
+    <input type="radio" name="radioquestion" id="rqa" value="1" /> <label for="rqa">one</label><br />
+    <input type="radio" name="radioquestion" id="rqb" value="2" checked="checked"/> <label for="rqb">two</label><br />
+    <input type="radio" name="radioquestion" id="rqc" value="3" /> <label for="rqc">three</label><br /><br />
+    <label for="selection">select:</label>
+    <select name="selection" size="0">
+        <option value="0">zero</option>
+        <option value="1">one</option>
+        <option value="2">two</option>
+        <option value="3">three</option>
+    </select><br /><br />
+    <label for="selection">select:</label>
+    <select name="multiselection" size="2" multiple="multiple">
+        <option value="0">zero</option>
+        <option value="1">one</option>
+        <option value="2">two</option>
+        <option value="3">three</option>
+    </select><br /><br /><br />
+    <label for="text">text area:</label><br />
+    <textarea cols="40" rows="3" name="text">line one
+    line two</textarea><br />
+    <br /><br /><br />
+    <input type="reset" name="reset" value="Reset" />
+    <input type="submit" name="submit" value="Submit" />
+    <input type="button" name="print" value="Print" onclick="print()" />
+    <input type="hidden" name="hiddenfield" value="OK" />
+    <br />
+    </form>
+    EOD
+
+    # output the HTML content
+    pdf.write_html(html, true, 0, true, 0)
+
+    # reset pointer to the last page
+    pdf.last_page()
+
+    # ---------------------------------------------------------
+
+    # Close and output PDF document
+    send_data pdf.output(), :type => "application/pdf", :disposition => "inline"
+  end
+end
+
+#============================================================+
+# END OF FILE
+#============================================================+

--- a/example/rails/app/controllers/example054_controller.rb
+++ b/example/rails/app/controllers/example054_controller.rb
@@ -65,6 +65,7 @@ class Example054Controller < ApplicationController
     <label for="password">password:</label> <input type="password" name="password" value="" size="20" maxlength="30" /><br /><br />
     <label for="infile">file:</label> <input type="file" name="userfile" size="20" /><br /><br />
     <input type="checkbox" name="agree" value="1" checked="checked"/> <label for="agree">I agree </label><br /><br />
+    <input type="checkbox" name="consent" value="1"/> <label for="consent">I consent </label><br /><br />
     <input type="radio" name="radioquestion" id="rqa" value="1" /> <label for="rqa">one</label><br />
     <input type="radio" name="radioquestion" id="rqb" value="2" checked="checked"/> <label for="rqb">two</label><br />
     <input type="radio" name="radioquestion" id="rqc" value="3" /> <label for="rqc">three</label><br /><br />

--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -234,7 +234,7 @@ class RBPDF
   # This is the class constructor.
   # It allows to set up the page format, the orientation and
   # the measure unit used in all the methods (except for the font sizes).
-  # @since 1.0
+  # [@since 1.0]
   # [@param string :orientation]
   #   page orientation. Possible values are (case insensitive):
   #   * P or Portrait (default)
@@ -6205,7 +6205,7 @@ protected
             if !pl['opt']['t'].nil? and pl['opt']['t'].is_a?(String)
               annots << ' /T ' + textannobjstring(pl['opt']['t'])
             end
-            # annots .= ' /Popup '
+            # annots << ' /Popup '
             if !pl['opt']['ca'].nil?
               annots << ' /CA ' + sprintf("%.4f", pl['opt']['ca'].to_f)
             end
@@ -8108,9 +8108,9 @@ protected
 
   #
   # get raw output stream.
-  # @param string :s string to output.
-  # @param int :n object reference for encryption mode
-  # @access protected
+  # [@param string :s] string to output.
+  # [@param int :n] object reference for encryption mode
+  # [@access protected]
   #
   def getrawstream(s, n=0)
     if n <= 0
@@ -8122,9 +8122,9 @@ protected
 
   #
   # Format output stream
-  # @param string :s string to output.
-  # @param int :n object reference for encryption mode
-  # @access protected
+  # [@param string :s] string to output.
+  # [@param int :n] object reference for encryption mode
+  # [@access protected]
   #
   def getstream(s, n=0)
     "stream\n" + getrawstream(s, n=0) + "\nendstream"

--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -12455,7 +12455,7 @@ protected
             dom[key]['text-indent'] = dom[parentkey]['text-indent']
           end
           # get attributes
-          attr_array = element.scan(/([^=\s]*)[\s]*=[\s]*"([^"]*)"/)
+          attr_array = element.scan(/([^=\s]+)[\s]*(?:=[\s]*"([^"]*)")*/)[1..-1]
           dom[key]['attribute'] = {} # reset attribute array
           attr_array.each do |name, value|
             dom[key]['attribute'][name.downcase] = value

--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -14521,8 +14521,8 @@ public
         @form_mode = 'post'
       end
     when 'input'
-      if tag['attribute']['name'] && !empty_string(tag['attribute']['name'])
-        name = tag['attribute']['name']
+      if tag['attribute']['type'] == 'checkbox' || (tag['attribute']['name'] && !empty_string(tag['attribute']['name']))
+        name = tag['attribute']['name'] || rand.to_s
         prop = {}
         opt = {}
         if tag['attribute']['value'] && !empty_string(tag['attribute']['value'])

--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -330,6 +330,7 @@ class RBPDF
     @listindent ||= 0
     @listindentlevel ||= 0
     @lispacer ||= ""
+    @li_position_x = nil
 
     # bookmark
     @outlines ||= []
@@ -13091,6 +13092,7 @@ public
     prev_listordered = @listordered
     prev_listcount = @listcount
     prev_lispacer = @lispacer
+    prev_li_position_x = @li_position_x
     @listnum = 0
     @listordered = []
     @listcount = []
@@ -14163,6 +14165,7 @@ public
     @listordered = prev_listordered
     @listcount = prev_listcount
     @lispacer = prev_lispacer
+    @li_position_x = prev_li_position_x
     dom = nil
   rescue => err
     Error('writeHTML Error.', err)
@@ -14479,6 +14482,7 @@ public
           @lispacer = '!'
         end
       end
+      @li_position_x = @x
     when 'blockquote'
       if @rtl
         @r_margin += @listindent
@@ -15016,9 +15020,11 @@ public
       @lasth = @font_size * @cell_height_ratio
     when 'dt'
       @lispacer = ''
+      @li_position_x = nil
       addHTMLVertSpace(0, 0, cell, firstorlast)
     when 'dd'
       @lispacer = ''
+      @li_position_x = nil
       if @rtl
         @r_margin -= @listindent
       else
@@ -15029,6 +15035,7 @@ public
     when 'ul', 'ol'
       @listnum -= 1
       @lispacer = ''
+      @li_position_x = nil
       if @rtl
         @r_margin -= @listindent
       else
@@ -15044,6 +15051,7 @@ public
       @lasth = @font_size * @cell_height_ratio
     when 'li'
       @lispacer = ''
+      @li_position_x = nil
       addHTMLVertSpace(0, 0, cell, firstorlast)
     when 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
       addHTMLVertSpace(hbz, hb, cell, firstorlast)
@@ -15291,6 +15299,7 @@ protected
     width = 0
     textitem = ''
     tmpx = @x
+    @x = @li_position_x
     lspace = GetStringWidth('  ')
     if listtype == '!'
       # set default list type for unordered list
@@ -15362,6 +15371,7 @@ protected
     end
     @x = tmpx
     @lispacer = ''
+    @li_position_x = nil
   end
 
   #
@@ -15399,6 +15409,7 @@ protected
       'listordered' => @listordered,
       'listcount' => @listcount,
       'lispacer' => @lispacer,
+      'li_position_x' => @li_position_x,
       'lasth' => @lasth,
       'h' => @h,
       'w' => @w,
@@ -15443,6 +15454,7 @@ protected
     @listordered = gvars['listordered']
     @listcount = gvars['listcount']
     @lispacer = gvars['lispacer']
+    @li_position_x = gvars['li_position_x']
     if option
       @lasth = gvars['lasth']
       @h = gvars['h']

--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -13569,317 +13569,318 @@ public
     end
     # Closing tag
     case (tag['value'])
-      when 'tr'
-        table_el = dom[(dom[key]['parent'])]['parent']
-        if parent['endy'].nil?
-          dom[(dom[key]['parent'])]['endy'] = @y
-          parent['endy'] = @y
-        end
-        if parent['endpage'].nil?
-          dom[(dom[key]['parent'])]['endpage'] = @page
-          parent['endpage'] = @page
-        end
-        # update row-spanned cells
-        if !dom[table_el]['rowspans'].nil?
-          dom[table_el]['rowspans'].each_with_index { |trwsp, k|
-            dom[table_el]['rowspans'][k]['rowspan'] -= 1
-            if dom[table_el]['rowspans'][k]['rowspan'] == 0
-              if dom[table_el]['rowspans'][k]['endpage'] == parent['endpage']
-                dom[(dom[key]['parent'])]['endy'] = [dom[table_el]['rowspans'][k]['endy'], parent['endy']].max
-              elsif dom[table_el]['rowspans'][k]['endpage'] > parent['endpage']
-                dom[(dom[key]['parent'])]['endy'] = dom[table_el]['rowspans'][k]['endy']
-                dom[(dom[key]['parent'])]['endpage'] = dom[table_el]['rowspans'][k]['endpage']
-              end
-            end
-          }
-          # report new endy and endpage to the rowspanned cells
-          dom[table_el]['rowspans'].each_with_index { |trwsp, k|
-            if dom[table_el]['rowspans'][k]['rowspan'] == 0
-              dom[table_el]['rowspans'][k]['endpage'] = [dom[table_el]['rowspans'][k]['endpage'], dom[(dom[key]['parent'])]['endpage']].max
-              dom[(dom[key]['parent'])]['endpage'] = dom[table_el]['rowspans'][k]['endpage']
-              dom[table_el]['rowspans'][k]['endy'] = [dom[table_el]['rowspans'][k]['endy'], dom[(dom[key]['parent'])]['endy']].max
+    when 'tr'
+      table_el = dom[(dom[key]['parent'])]['parent']
+      if parent['endy'].nil?
+        dom[(dom[key]['parent'])]['endy'] = @y
+        parent['endy'] = @y
+      end
+      if parent['endpage'].nil?
+        dom[(dom[key]['parent'])]['endpage'] = @page
+        parent['endpage'] = @page
+      end
+      # update row-spanned cells
+      if !dom[table_el]['rowspans'].nil?
+        dom[table_el]['rowspans'].each_with_index { |trwsp, k|
+          dom[table_el]['rowspans'][k]['rowspan'] -= 1
+          if dom[table_el]['rowspans'][k]['rowspan'] == 0
+            if dom[table_el]['rowspans'][k]['endpage'] == parent['endpage']
+              dom[(dom[key]['parent'])]['endy'] = [dom[table_el]['rowspans'][k]['endy'], parent['endy']].max
+            elsif dom[table_el]['rowspans'][k]['endpage'] > parent['endpage']
               dom[(dom[key]['parent'])]['endy'] = dom[table_el]['rowspans'][k]['endy']
-            end
-          }
-          # update remaining rowspanned cells
-          dom[table_el]['rowspans'].each_with_index { |trwsp, k|
-            if dom[table_el]['rowspans'][k]['rowspan'] == 0
-              dom[table_el]['rowspans'][k]['endpage'] = dom[(dom[key]['parent'])]['endpage']
-              dom[table_el]['rowspans'][k]['endy'] = dom[(dom[key]['parent'])]['endy']
-            end
-          }
-        end
-        if (@num_columns > 1) and (dom[(dom[key]['parent'])]['endy'] >= (@page_break_trigger - @lasth)) and (@y < dom[(dom[key]['parent'])]['endy'])
-          Ln(0, cell)
-        else
-          setPage(dom[(dom[key]['parent'])]['endpage']);
-          @y = dom[(dom[key]['parent'])]['endy']
-          if !dom[table_el]['attribute']['cellspacing'].nil?
-            cellspacing = getHTMLUnitToUnits(dom[table_el]['attribute']['cellspacing'], 1, 'px')
-            @y += cellspacing
-          end
-          Ln(0, cell)
-          @x = parent['startx']
-          # account for booklet mode
-          if parent['startpage'] and @page > parent['startpage']
-            if @rtl and (@pagedim[@page]['orm'] != @pagedim[parent['startpage']]['orm'])
-              @x -= @pagedim[@page]['orm'] - @pagedim[parent['startpage']]['orm']
-            elsif !@rtl and (@pagedim[@page]['olm'] != @pagedim[parent['startpage']]['olm'])
-              @x += @pagedim[@page]['olm'] - @pagedim[parent['startpage']]['olm']
+              dom[(dom[key]['parent'])]['endpage'] = dom[table_el]['rowspans'][k]['endpage']
             end
           end
+        }
+        # report new endy and endpage to the rowspanned cells
+        dom[table_el]['rowspans'].each_with_index { |trwsp, k|
+          if dom[table_el]['rowspans'][k]['rowspan'] == 0
+            dom[table_el]['rowspans'][k]['endpage'] = [dom[table_el]['rowspans'][k]['endpage'], dom[(dom[key]['parent'])]['endpage']].max
+            dom[(dom[key]['parent'])]['endpage'] = dom[table_el]['rowspans'][k]['endpage']
+            dom[table_el]['rowspans'][k]['endy'] = [dom[table_el]['rowspans'][k]['endy'], dom[(dom[key]['parent'])]['endy']].max
+            dom[(dom[key]['parent'])]['endy'] = dom[table_el]['rowspans'][k]['endy']
+          end
+        }
+        # update remaining rowspanned cells
+        dom[table_el]['rowspans'].each_with_index { |trwsp, k|
+          if dom[table_el]['rowspans'][k]['rowspan'] == 0
+            dom[table_el]['rowspans'][k]['endpage'] = dom[(dom[key]['parent'])]['endpage']
+            dom[table_el]['rowspans'][k]['endy'] = dom[(dom[key]['parent'])]['endy']
+          end
+        }
+      end
+      if (@num_columns > 1) and (dom[(dom[key]['parent'])]['endy'] >= (@page_break_trigger - @lasth)) and (@y < dom[(dom[key]['parent'])]['endy'])
+        Ln(0, cell)
+      else
+        setPage(dom[(dom[key]['parent'])]['endpage']);
+        @y = dom[(dom[key]['parent'])]['endy']
+        if !dom[table_el]['attribute']['cellspacing'].nil?
+          cellspacing = getHTMLUnitToUnits(dom[table_el]['attribute']['cellspacing'], 1, 'px')
+          @y += cellspacing
         end
-      when 'table'
-        if dom[(dom[key]['parent'])]['attribute']['tablehead'] and dom[(dom[key]['parent'])]['attribute']['tablehead'] == "1"
-          # closing tag used for the thead part
-          in_table_head = true
-          @in_thead = false
+        Ln(0, cell)
+        @x = parent['startx']
+        # account for booklet mode
+        if parent['startpage'] and @page > parent['startpage']
+          if @rtl and (@pagedim[@page]['orm'] != @pagedim[parent['startpage']]['orm'])
+            @x -= @pagedim[@page]['orm'] - @pagedim[parent['startpage']]['orm']
+          elsif !@rtl and (@pagedim[@page]['olm'] != @pagedim[parent['startpage']]['olm'])
+            @x += @pagedim[@page]['olm'] - @pagedim[parent['startpage']]['olm']
+          end
         end
+      end
+    when 'table'
+      if dom[(dom[key]['parent'])]['attribute']['tablehead'] and dom[(dom[key]['parent'])]['attribute']['tablehead'] == "1"
+        # closing tag used for the thead part
+        in_table_head = true
+        @in_thead = false
+      end
 
-        table_el = parent
-        # draw borders
-        if (!table_el['attribute']['border'].nil? and (table_el['attribute']['border'].to_i > 0)) or (!table_el['style'].nil? and !table_el['style']['border'].nil? and (table_el['style']['border'].to_i > 0))
-          border = 1
-        else
-          border = 0
-        end
+      table_el = parent
+      # draw borders
+      if (!table_el['attribute']['border'].nil? and (table_el['attribute']['border'].to_i > 0)) or (!table_el['style'].nil? and !table_el['style']['border'].nil? and (table_el['style']['border'].to_i > 0))
+        border = 1
+      else
+        border = 0
+      end
 
-        startpage = 0
-        end_page = 0
-        # fix bottom line alignment of last line before page break
-        dom[(dom[key]['parent'])]['trids'].each_with_index { |trkey, j|
+      startpage = 0
+      end_page = 0
+      # fix bottom line alignment of last line before page break
+      dom[(dom[key]['parent'])]['trids'].each_with_index { |trkey, j|
+        # update row-spanned cells
+        if !dom[(dom[key]['parent'])]['rowspans'].nil?
+          dom[(dom[key]['parent'])]['rowspans'].each_with_index { |trwsp, k|
+            if trwsp['trid'] == trkey
+              dom[(dom[key]['parent'])]['rowspans'][k]['mrowspan'] -= 1
+            end
+            if defined?(prevtrkey) and (trwsp['trid'] == prevtrkey) and (trwsp['mrowspan'] >= 0)
+              dom[(dom[key]['parent'])]['rowspans'][k]['trid'] = trkey
+            end
+          }
+        end
+        if defined?(prevtrkey) and (dom[trkey]['startpage'] > dom[prevtrkey]['endpage'])
+          pgendy = @pagedim[dom[prevtrkey]['endpage']]['hk'] - @pagedim[dom[prevtrkey]['endpage']]['bm']
+          dom[prevtrkey]['endy'] = pgendy
           # update row-spanned cells
           if !dom[(dom[key]['parent'])]['rowspans'].nil?
             dom[(dom[key]['parent'])]['rowspans'].each_with_index { |trwsp, k|
-              if trwsp['trid'] == trkey
-                dom[(dom[key]['parent'])]['rowspans'][k]['mrowspan'] -= 1
-              end
-              if defined?(prevtrkey) and (trwsp['trid'] == prevtrkey) and (trwsp['mrowspan'] >= 0)
-                dom[(dom[key]['parent'])]['rowspans'][k]['trid'] = trkey
+              if (trwsp['trid'] == trkey) and (trwsp['mrowspan'] > 1) and (trwsp['endpage'] == dom[prevtrkey]['endpage'])
+                dom[(dom[key]['parent'])]['rowspans'][k]['endy'] = pgendy
+                dom[(dom[key]['parent'])]['rowspans'][k]['mrowspan'] = -1
               end
             }
           end
-          if defined?(prevtrkey) and (dom[trkey]['startpage'] > dom[prevtrkey]['endpage'])
-            pgendy = @pagedim[dom[prevtrkey]['endpage']]['hk'] - @pagedim[dom[prevtrkey]['endpage']]['bm']
-            dom[prevtrkey]['endy'] = pgendy
-            # update row-spanned cells
-            if !dom[(dom[key]['parent'])]['rowspans'].nil?
-              dom[(dom[key]['parent'])]['rowspans'].each_with_index { |trwsp, k|
-                if (trwsp['trid'] == trkey) and (trwsp['mrowspan'] > 1) and (trwsp['endpage'] == dom[prevtrkey]['endpage'])
-                  dom[(dom[key]['parent'])]['rowspans'][k]['endy'] = pgendy
-                  dom[(dom[key]['parent'])]['rowspans'][k]['mrowspan'] = -1
-                end
-              }
-            end
+        end
+        prevtrkey = trkey
+        table_el = dom[(dom[key]['parent'])].dup
+      }
+      # for each row
+      table_el['trids'].each_with_index { |trkey, j|
+        parent = dom[trkey]
+        # for each cell on the row
+        parent['cellpos'].each_with_index { |cellpos, k|
+          if !cellpos['rowspanid'].nil? and (cellpos['rowspanid'] >= 0)
+            cellpos['startx'] = table_el['rowspans'][(cellpos['rowspanid'])]['startx']
+            cellpos['endx'] = table_el['rowspans'][(cellpos['rowspanid'])]['endx']
+            endy = table_el['rowspans'][(cellpos['rowspanid'])]['endy']
+            startpage = table_el['rowspans'][(cellpos['rowspanid'])]['startpage']
+            end_page = table_el['rowspans'][(cellpos['rowspanid'])]['endpage']
+          else
+            endy = parent['endy']
+            startpage = parent['startpage']
+            end_page = parent['endpage']
           end
-          prevtrkey = trkey
-          table_el = dom[(dom[key]['parent'])].dup
-        }
-        # for each row
-        table_el['trids'].each_with_index { |trkey, j|
-          parent = dom[trkey]
-          # for each cell on the row
-          parent['cellpos'].each_with_index { |cellpos, k|
-            if !cellpos['rowspanid'].nil? and (cellpos['rowspanid'] >= 0)
-              cellpos['startx'] = table_el['rowspans'][(cellpos['rowspanid'])]['startx']
-              cellpos['endx'] = table_el['rowspans'][(cellpos['rowspanid'])]['endx']
-              endy = table_el['rowspans'][(cellpos['rowspanid'])]['endy']
-              startpage = table_el['rowspans'][(cellpos['rowspanid'])]['startpage']
-              end_page = table_el['rowspans'][(cellpos['rowspanid'])]['endpage']
-            else
-              endy = parent['endy']
-              startpage = parent['startpage']
-              end_page = parent['endpage']
-            end
-            cellpos['startx'] ||= 0
-            if end_page > startpage
-              # design borders around HTML cells.
-              startpage.upto(end_page) do |page|
-                setPage(page)
-                if page == startpage
-                  @y = parent['starty'] # put cursor at the beginning of row on the first page
-                  ch = getPageHeight() - parent['starty'] - getBreakMargin()
-                  cborder = getBorderMode(border, position='start')
-                elsif page == end_page
-                  @y = @t_margin # put cursor at the beginning of last page
-                  ch = endy - @t_margin
-                  cborder = getBorderMode(border, position='end')
-                else
-                  @y = @t_margin # put cursor at the beginning of the current page
-                  ch = getPageHeight() - @t_margin - getBreakMargin()
-                  cborder = getBorderMode(border, position='middle')
-                end
-                if !cellpos['bgcolor'].nil? and (cellpos['bgcolor'] != false)
-                  SetFillColorArray(cellpos['bgcolor'])
-                  fill = 1
-                else
-                  fill = 0
-                end
-                cw = (cellpos['endx'] - cellpos['startx']).abs
-                @x = cellpos['startx']
-                # account for margin changes
-                if page > startpage
-                  if @rtl and (@pagedim[page]['orm'] != @pagedim[startpage]['orm'])
-                    @x -= @pagedim[page]['orm'] - @pagedim[startpage]['orm']
-                  elsif !@rtl and (@pagedim[page]['lm'] != @pagedim[startpage]['olm'])
-                    @x += @pagedim[page]['olm'] - @pagedim[startpage]['olm']
-                  end
-                end
-
-                prevLastH = @lasth
-                # design a cell around the text
-                ccode = @fill_color + "\n" + getCellCode(cw, ch, '', cborder, 1, '', fill, '', 0, true)
-                @lasth = prevLastH
-
-                if (cborder != 0) or (fill == 1)
-                  pagebuff = getPageBuffer(@page)
-                  pstart = pagebuff[0, @intmrk[@page]]
-                  pend = pagebuff[@intmrk[@page]..-1]
-                  setPageBuffer(@page, pstart + ccode + "\n" + pend)
-                  @intmrk[@page] += (ccode + "\n").length
-                end
+          cellpos['startx'] ||= 0
+          if end_page > startpage
+            # design borders around HTML cells.
+            startpage.upto(end_page) do |page|
+              setPage(page)
+              if page == startpage
+                @y = parent['starty'] # put cursor at the beginning of row on the first page
+                ch = getPageHeight() - parent['starty'] - getBreakMargin()
+                cborder = getBorderMode(border, position='start')
+              elsif page == end_page
+                @y = @t_margin # put cursor at the beginning of last page
+                ch = endy - @t_margin
+                cborder = getBorderMode(border, position='end')
+              else
+                @y = @t_margin # put cursor at the beginning of the current page
+                ch = getPageHeight() - @t_margin - getBreakMargin()
+                cborder = getBorderMode(border, position='middle')
               end
-            else
-              setPage(startpage)
               if !cellpos['bgcolor'].nil? and (cellpos['bgcolor'] != false)
                 SetFillColorArray(cellpos['bgcolor'])
                 fill = 1
               else
                 fill = 0
               end
-              @x = cellpos['startx']
-              @y = parent['starty']
               cw = (cellpos['endx'] - cellpos['startx']).abs
-              ch = endy - parent['starty']
+              @x = cellpos['startx']
+              # account for margin changes
+              if page > startpage
+                if @rtl and (@pagedim[page]['orm'] != @pagedim[startpage]['orm'])
+                  @x -= @pagedim[page]['orm'] - @pagedim[startpage]['orm']
+                elsif !@rtl and (@pagedim[page]['lm'] != @pagedim[startpage]['olm'])
+                  @x += @pagedim[page]['olm'] - @pagedim[startpage]['olm']
+                end
+              end
 
               prevLastH = @lasth
               # design a cell around the text
-              ccode = @fill_color + "\n" + getCellCode(cw, ch, '', border, 1, '', fill, '', 0, true)
+              ccode = @fill_color + "\n" + getCellCode(cw, ch, '', cborder, 1, '', fill, '', 0, true)
               @lasth = prevLastH
 
-              if (border != 0) or (fill == 1)
-                if !@transfmrk[@page].nil?
-                  pagemark = @transfmrk[@page]
-                  @transfmrk[@page] += (ccode + "\n").length
-                elsif @in_footer
-                  pagemark = @footerpos[@page]
-                  @footerpos[@page] += (ccode + "\n").length
-                else
-                  pagemark = @intmrk[@page]
-                  @intmrk[@page] += (ccode + "\n").length
-                end
+              if (cborder != 0) or (fill == 1)
                 pagebuff = getPageBuffer(@page)
-                pstart = pagebuff[0, pagemark]
-                pend = pagebuff[pagemark..-1]
+                pstart = pagebuff[0, @intmrk[@page]]
+                pend = pagebuff[@intmrk[@page]..-1]
                 setPageBuffer(@page, pstart + ccode + "\n" + pend)
+                @intmrk[@page] += (ccode + "\n").length
               end
             end
-          }
-          if !table_el['attribute']['cellspacing'].nil?
-            cellspacing = getHTMLUnitToUnits(table_el['attribute']['cellspacing'], 1, 'px')
-            @y += cellspacing
-          end
-          Ln(0, cell)
-          @x = parent['startx']
-          if end_page > startpage
-            if @rtl and (@pagedim[end_page]['orm'] != @pagedim[startpage]['orm'])
-              @x += @pagedim[end_page]['orm'] - @pagedim[startpage]['orm']
-            elsif !@rtl and (@pagedim[end_page]['olm'] != @pagedim[startpage]['olm'])
-              @x += @pagedim[end_page]['olm'] - @pagedim[startpage]['olm']
+          else
+            setPage(startpage)
+            if !cellpos['bgcolor'].nil? and (cellpos['bgcolor'] != false)
+              SetFillColorArray(cellpos['bgcolor'])
+              fill = 1
+            else
+              fill = 0
+            end
+            @x = cellpos['startx']
+            @y = parent['starty']
+            cw = (cellpos['endx'] - cellpos['startx']).abs
+            ch = endy - parent['starty']
+
+            prevLastH = @lasth
+            # design a cell around the text
+            ccode = @fill_color + "\n" + getCellCode(cw, ch, '', border, 1, '', fill, '', 0, true)
+            @lasth = prevLastH
+
+            if (border != 0) or (fill == 1)
+              if !@transfmrk[@page].nil?
+                pagemark = @transfmrk[@page]
+                @transfmrk[@page] += (ccode + "\n").length
+              elsif @in_footer
+                pagemark = @footerpos[@page]
+                @footerpos[@page] += (ccode + "\n").length
+              else
+                pagemark = @intmrk[@page]
+                @intmrk[@page] += (ccode + "\n").length
+              end
+              pagebuff = getPageBuffer(@page)
+              pstart = pagebuff[0, pagemark]
+              pend = pagebuff[pagemark..-1]
+              setPageBuffer(@page, pstart + ccode + "\n" + pend)
             end
           end
         }
-        if !in_table_head
-          # we are not inside a thead section
-          if dom[(parent['parent'])]['attribute']['cellpadding'] ### fix ###
-            @c_margin = @old_c_margin
-          end
-          @lasth = @font_size * @cell_height_ratio
-          if (@page == @numpages - 1) and @pageopen[@numpages]
-            # remove last blank page
-            deletePage(@numpages)
-          end
-          if !@thead_margins['top'].nil?
-            # restore top margin
-            @t_margin = @thead_margins['top']
-            @pagedim[@page]['tm'] = @t_margin
-          end
-          if table_el['attribute']['nested'].nil? or (table_el['attribute']['nested'] != 'true')
-            # reset main table header
-            @thead = ''
-            @thead_margins = {}
+        if !table_el['attribute']['cellspacing'].nil?
+          cellspacing = getHTMLUnitToUnits(table_el['attribute']['cellspacing'], 1, 'px')
+          @y += cellspacing
+        end
+        Ln(0, cell)
+        @x = parent['startx']
+        if end_page > startpage
+          if @rtl and (@pagedim[end_page]['orm'] != @pagedim[startpage]['orm'])
+            @x += @pagedim[end_page]['orm'] - @pagedim[startpage]['orm']
+          elsif !@rtl and (@pagedim[end_page]['olm'] != @pagedim[startpage]['olm'])
+            @x += @pagedim[end_page]['olm'] - @pagedim[startpage]['olm']
           end
         end
-        if tag['block']
-          unless dom[(dom[key]['parent'])]['attribute']['tablehead'] and dom[(dom[key]['parent'])]['attribute']['tablehead'] == "1" ### fix ###
-            addHTMLVertSpace(hbz / 2, 0, cell, (dom[key+1].nil? or (dom[key+1]['value'] != 'table'))) ### fix ###
-          end
-        end
-      when 'a'
-        @href = {}
-        @html_anchor = nil
-      when 'sup'
-        SetXY(GetX(), GetY() + (0.7 * parent['fontsize'] / @k))
-      when 'sub'
-        SetXY(GetX(), GetY() - (0.3 * parent['fontsize'] / @k))
-      when 'div'
-        addHTMLVertSpace(hbz, 0, cell, firstorlast)
-      when 'blockquote'
-        if @rtl
-          @r_margin -= @listindent
-        else
-          @l_margin -= @listindent
-        end
-        @listindentlevel -= 1
-        addHTMLVertSpace(hbz, hb, cell, firstorlast)
-      when 'p'
-        addHTMLVertSpace(hbz, hb, cell, firstorlast)
-      when 'pre'
-        addHTMLVertSpace(hbz, hb, cell, firstorlast)
-        @premode = false
-      when 'dl'
-        @listnum -= 1
-        if @listnum <= 0
-          @listnum = 0
-          addHTMLVertSpace(hbz, hb, cell, firstorlast)
-        else
-          addHTMLVertSpace(0, 0, cell, firstorlast)
+      }
+      if !in_table_head
+        # we are not inside a thead section
+        if dom[(parent['parent'])]['attribute']['cellpadding'] ### fix ###
+          @c_margin = @old_c_margin
         end
         @lasth = @font_size * @cell_height_ratio
-      when 'dt'
-        @lispacer = ''
-        addHTMLVertSpace(0, 0, cell, firstorlast)
-      when 'dd'
-        @lispacer = ''
-        if @rtl
-          @r_margin -= @listindent
-        else
-          @l_margin -= @listindent
+        if (@page == @numpages - 1) and @pageopen[@numpages]
+          # remove last blank page
+          deletePage(@numpages)
         end
-        @listindentlevel -= 1
-        addHTMLVertSpace(0, 0, cell, firstorlast)
-      when 'ul', 'ol'
-        @listnum -= 1
-        @lispacer = ''
-        if @rtl
-          @r_margin -= @listindent
-        else
-          @l_margin -= @listindent
+        if !@thead_margins['top'].nil?
+          # restore top margin
+          @t_margin = @thead_margins['top']
+          @pagedim[@page]['tm'] = @t_margin
         end
-        @listindentlevel -= 1
-        if @listnum <= 0
-          @listnum = 0
-          addHTMLVertSpace(hbz, hb, cell, firstorlast)
-        else
-          addHTMLVertSpace(0, 0, cell, firstorlast)
+        if table_el['attribute']['nested'].nil? or (table_el['attribute']['nested'] != 'true')
+          # reset main table header
+          @thead = ''
+          @thead_margins = {}
         end
-        @lasth = @font_size * @cell_height_ratio
-      when 'li'
-        @lispacer = ''
-        addHTMLVertSpace(0, 0, cell, firstorlast)
-      when 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
+      end
+      if tag['block']
+        unless dom[(dom[key]['parent'])]['attribute']['tablehead'] and dom[(dom[key]['parent'])]['attribute']['tablehead'] == "1" ### fix ###
+          addHTMLVertSpace(hbz / 2, 0, cell, (dom[key+1].nil? or (dom[key+1]['value'] != 'table'))) ### fix ###
+        end
+      end
+    when 'a'
+      @href = {}
+      @html_anchor = nil
+    when 'sup'
+      SetXY(GetX(), GetY() + (0.7 * parent['fontsize'] / @k))
+    when 'sub'
+      SetXY(GetX(), GetY() - (0.3 * parent['fontsize'] / @k))
+    when 'div'
+      addHTMLVertSpace(hbz, 0, cell, firstorlast)
+    when 'blockquote'
+      if @rtl
+        @r_margin -= @listindent
+      else
+        @l_margin -= @listindent
+      end
+      @listindentlevel -= 1
+      addHTMLVertSpace(hbz, hb, cell, firstorlast)
+    when 'p'
+      addHTMLVertSpace(hbz, hb, cell, firstorlast)
+    when 'pre'
+      addHTMLVertSpace(hbz, hb, cell, firstorlast)
+      @premode = false
+    when 'dl'
+      @listnum -= 1
+      if @listnum <= 0
+        @listnum = 0
         addHTMLVertSpace(hbz, hb, cell, firstorlast)
+      else
+        addHTMLVertSpace(0, 0, cell, firstorlast)
+      end
+      @lasth = @font_size * @cell_height_ratio
+    when 'dt'
+      @lispacer = ''
+      addHTMLVertSpace(0, 0, cell, firstorlast)
+    when 'dd'
+      @lispacer = ''
+      if @rtl
+        @r_margin -= @listindent
+      else
+        @l_margin -= @listindent
+      end
+      @listindentlevel -= 1
+      addHTMLVertSpace(0, 0, cell, firstorlast)
+    when 'ul', 'ol'
+      @listnum -= 1
+      @lispacer = ''
+      if @rtl
+        @r_margin -= @listindent
+      else
+        @l_margin -= @listindent
+      end
+      @listindentlevel -= 1
+      if @listnum <= 0
+        @listnum = 0
+        addHTMLVertSpace(hbz, hb, cell, firstorlast)
+      else
+        addHTMLVertSpace(0, 0, cell, firstorlast)
+      end
+      @lasth = @font_size * @cell_height_ratio
+    when 'li'
+      @lispacer = ''
+      addHTMLVertSpace(0, 0, cell, firstorlast)
+    when 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
+      addHTMLVertSpace(hbz, hb, cell, firstorlast)
     end
+
     if dom[(dom[key]['parent'])]['attribute']['pagebreakafter']
       pba = dom[(dom[key]['parent'])]['attribute']['pagebreakafter']
       # check for pagebreak

--- a/test/rbpdf_dom_test.rb
+++ b/test/rbpdf_dom_test.rb
@@ -48,6 +48,9 @@ class RbpdfTest < Test::Unit::TestCase
     'Attribute'       => {:html => '<p style="text-align:justify">abc</p>', :length => 4,
                           :params => [{:parent => 0, :tag => false, :attribute => {}}, # parent -> Root
                                       {:parent => 0, :tag => true,  :value => 'p',     :elkey => 0, :opening => true, :align => 'J', :attribute => {:style => 'text-align:justify;'}}]},
+    'Boolean Attribute' => {:html => '<input checked />', :length => 2,
+                          :params => [{:parent => 0, :tag => false, :attribute => {}}, # parent -> Root
+                                      {:parent => 0, :tag => true,  :value => 'input', :elkey => 0, :opening => true, :attribute => {:checked => nil}}]},
     'Table border'    => {:html => '<table border="1"><tr><td>abc</td></tr></table>', :length => 9,
                               # -> '<table border="1"><tr><td>abc<marker style="font-size:0"/></td></tr></table>' ## added marker tag (by getHtmlDomArray()) ##
                           :params => [{:parent => 0, :tag => false, :attribute => {}}, # parent -> Root
@@ -81,7 +84,7 @@ class RbpdfTest < Test::Unit::TestCase
   test "Dom Basic test" do |data|
     pdf = RBPDF.new
     dom = pdf.send(:getHtmlDomArray, data[:html])
-    assert_equal data[:length], dom.length if data[:length]
+    assert_equal "#{data[:html]} #{data[:length]}", "#{data[:html]} #{dom.length}" if data[:length]
     data[:params].each_with_index {|param, i|
       # validated length check (for Rails 4.2 later)
       if dom[i].nil? and i >= data[:validated_length]
@@ -172,6 +175,16 @@ class RbpdfTest < Test::Unit::TestCase
     dom1 = pdf.send(:getHtmlDomArray, '<b>ab<hr/>c</b>')
     dom2 = pdf.send(:getHtmlDomArray, '<b>ab<hr>c</b>')
     assert_equal dom1, dom2
+  end
+
+  test "Dom self close tag Boolean attribute test" do
+    pdf = RBPDF.new
+
+    dom = pdf.send(:getHtmlDomArray, '<input checked="checked" />')
+    dom2 = pdf.send(:getHtmlDomArray, '<input checked /></input>')
+    assert_equal dom, dom2
+
+    assert_equal({"checked" => nil}, dom[1]['attribute'])
   end
 
   test "Dom HTMLTagHandler Basic test" do

--- a/test/rbpdf_examples_test.rb
+++ b/test/rbpdf_examples_test.rb
@@ -56,6 +56,7 @@ class RbpdfTest < Test::Unit::TestCase
     '047 : Transactions'                                    => '047',
     '048 : HTML tables and table headers'                   => '048',
 #    '051 : Full page background'                            => '051',
+    '054 : XHTML Form'                                      => '054',
     '055 : Display all characters available on core fonts.' => '055',
     '057 : Cell vertical alignments'                        => '057',
     '059 : Table Of Content using HTML templates.'          => '059',

--- a/test/rbpdf_examples_test.rb
+++ b/test/rbpdf_examples_test.rb
@@ -27,6 +27,7 @@ class RbpdfTest < Test::Unit::TestCase
     '009 : Test Image'                                      => '009',
     '011 : Colored Table'                                   => '011',
     '012 : Graphic Functions'                               => '012',
+    '014 : Javascript and Forms'                            => '014',
     '015 : Bookmarks (Table of Content)'                    => '015',
     '017 : Two independent columns with MultiCell'          => '017',
     '018 : RTL document with Persian language'              => '018',

--- a/test/rbpdf_form_func_test.rb
+++ b/test/rbpdf_form_func_test.rb
@@ -1,0 +1,651 @@
+# coding: ASCII-8BIT
+# Copyright (c) 2011-2023 NAITOH Jun
+# Released under the MIT license
+# http://www.opensource.org/licenses/MIT
+
+require 'test_helper'
+
+class RbpdfFormFuncTest < Test::Unit::TestCase
+  test "JScolor test" do
+    pdf = RBPDF.new
+    pdf.add_page
+
+    valid_color_code = '#ff0000'
+    result = pdf.send(:JScolor, valid_color_code)
+    assert_equal "['RGB',1.000,0.000,0.000]", result
+
+    valid_color_name = 'black'
+    result = pdf.send(:JScolor, valid_color_name)
+    assert_equal 'color.black', result
+
+    invalid_color_code = '#zzzzzz'
+    result = pdf.send(:JScolor, invalid_color_code)
+    assert_equal "['RGB',0.000,0.000,0.000]", result
+
+    assert_raise(RBPDFError) {pdf.send(:JScolor, 'invalid_color_name')}
+  end
+
+  test "getAnnotOptFromJSProp test" do
+    pdf = RBPDF.new
+    pdf.add_page
+
+    # the annotation options area already defined
+    prop = { 'aopt' => ['foo', 'bar'] }
+    result = pdf.send(:getAnnotOptFromJSProp, prop)
+    assert_equal ['foo', 'bar'], result
+
+    # the annotation options area not defined
+    prop = {
+      'alignment' => 'center',
+      'border' => [0, 0, 3],
+      'charLimit' => '20',
+      'lineWidth' => 2,
+      'borderStyle' => 'beveled',
+      'buttonAlignX' => 0.7,
+      'buttonAlignY' => 0.7,
+      'buttonFitBounds' => 'true',
+      'buttonPosition' => 'position.iconTextV',
+      'buttonScaleHow' => 'scaleHow.proportional',
+      'buttonScaleWhen' => 'scaleWhen.tooSmall',
+      'fillColor' => [255, 255, 255],
+      'rotation' => 90,
+      'strokeColor'=>[128, 128, 128],
+      'readonly' => 'true',
+      'required' => 'true',
+      'password' => 'true',
+      'multiline' => 'true',
+      'NoToggleToOff' => 'true',
+      'Radio' => 'true',
+      'Pushbutton' => 'true',
+      'Combo' => 'true',
+      'editable' => 'true',
+      'Sort' => 'true',
+      'fileSelect' => 'true',
+      'multipleSelection' => 'true',
+      'doNotSpellCheck' => 'true',
+      'doNotScroll' => 'true',
+      'comb' => 'true',
+      'radiosInUnison' => 'true',
+      'richText' => 'true',
+      'commitOnSelChange' => 'true',
+      'display' => 'display.noPrint',
+      'currentValueIndices'=>[1, 3],
+      'value' => [0, 0, 3, 4],
+      'exportValues' => ['North', 'East', 'South', 'West'],
+      'richValue' => [],
+      'submitName' => 'submitName',
+      'name' => 'name',
+      'userName' => 'userName',
+      'highlight' => 'highlight.n',
+    }
+    expected = {
+      'border' => [0, 0, 3],
+      'bs' => {'w'=>2, 's'=>'B'},
+      'f' => '0100_0000'.to_i(2),
+      'ff' => '0111_1111_1111_1111_0000_0000_0011'.gsub('_', '').to_i(2),
+      'h' => 'N',
+      'i' => [1, 3],
+      'maxlen' => 20,
+      'mk' => {
+        'bg' => [255, 255, 255],
+        'bc' => [128, 128, 128],
+        'if' => {
+          'a' => [0.7, 0.7],
+          'fb' => true,
+          's' => 'P',
+          'sw' => 'S'
+        },
+        'r' => 90,
+        'tp' => 2,
+      },
+      'opt' => [['North', 0], ['East', 0], ['South', 3], ['West', 4]],
+      'q' => 1,
+      'rv' => [],
+      't' => 'name',
+      'tm' => 'submitName',
+      'tu' => 'userName',
+    }
+    result = pdf.send(:getAnnotOptFromJSProp, prop)
+    assert_equal expected, result
+  end
+
+  def addfield_result(type, name, x, y, w, h, pdf)
+    @h = pdf.get_page_height
+    k = pdf.get_scale_factor
+    font_size_pt = pdf.get_font_size_pt
+    <<~EOS
+      if(getField('tcpdfdocsaved').value != 'saved') {f#{name}=this.addField('#{name}','#{type}',#{pdf.PageNo() - 1},[#{sprintf("%.2f,%.2f,%.2f,%.2f", x * k, (@h - y) * k + 1, (x + w) * k, (@h - y - h) * k + 1)}]);
+      f#{name}.textSize=#{font_size_pt};
+    EOS
+  end
+
+  test "addfield test" do
+    pdf = RBPDF.new
+    pdf.add_page
+    type = 'text'
+    name = 'field1'
+    x = 10
+    y = 10
+    w = 50
+    h = 10
+
+    expected = addfield_result(type, name, x, y, w, h, pdf)
+    expected << "f#{name}.fillColor=['RGB',1.000,1.000,1.000];\n"
+    expected << "f#{name}.textColor=['RGB',0.000,0.000,0.000];\n}"
+    result = pdf.send(:addfield, type, name, x, y, w, h, {'fillColor' => '#ffffff', 'textColor' => '#000000'})
+    assert_equal expected, result
+
+    expected << addfield_result(type, name, x, y, w, h, pdf)
+    expected << "f#{name}.required='true';\n"
+    expected << "f#{name}.maxlength='10';\n}"
+    result = pdf.send(:addfield, type, name, x, y, w, h, {'required' => true, 'maxlength' => 10})
+    assert_equal expected, result
+  end
+
+  test "TextField test" do
+    # Check javascript
+    pdf = RBPDF.new
+    pdf.add_page
+    name = 'test_field'
+    x = 50
+    y = 50
+    w = 100
+    h = 50
+    prop = {'required' => 'true', 'maxlength' => 10}
+
+    expected = addfield_result('text', name, x, y, w, h, pdf)
+    expected << "f#{name}.required='true';\n"
+    expected << "f#{name}.maxlength='10';\n}"
+
+    pdf.TextField(name, w, h, prop, {}, x, y, true)
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal expected, javascript
+
+    # Check Annotation
+    opt = {'maxlen' => 10}
+    eopt = {
+      'Subtype' => 'Widget',
+      'ap' => { 'n' => 'q BT /F1 12.00 Tf 0 g ET Q' },
+      'border' => [0, 0, 1],
+      'bs' => { 's' => 'S', 'w' => 1 },
+      'maxlen' => 10,
+      'da' => '/F1 12.00 Tf 0 g',
+      'f' => '0000_0100'.to_i(2),
+      'ft' => 'Tx',
+      'ff' => '0000_0000_0000_0000_0000_0000_0010'.gsub('_', '').to_i(2), # required
+      'mk'=>{
+        'bc' => [128, 128, 128],
+        'bg' => [255, 255, 255],
+        'if' => { 'a' => [0.5, 0.5] },
+      },
+      't' => name,
+    }
+
+    pdf = RBPDF.new
+    pdf.TextField(name, w, h, prop, opt, 50, 50) # js = false
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal '', javascript
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_equal 0,    page_annots[1][0]['numspaces']
+    assert_equal x,    page_annots[1][0]['x']
+    assert_equal y,    page_annots[1][0]['y']
+    assert_equal w,    page_annots[1][0]['w']
+    assert_equal h,    page_annots[1][0]['h']
+    assert_equal eopt, page_annots[1][0]['opt']
+    assert_equal name, page_annots[1][0]['txt']
+  end
+
+  test "RadioButton test" do
+    # Check javascript
+    pdf = RBPDF.new
+    pdf.add_page
+    name = 'radio'
+    x = 50
+    y = 50
+    w = 100
+    h = 50
+    prop = {'required' => 'true', 'maxlength' => 10}
+
+    expected = addfield_result('radiobutton', name, x, y, w, w, pdf)
+    expected << "f#{name}.required='true';\n"
+    expected << "f#{name}.maxlength='10';\n}"
+
+    pdf.RadioButton(name, w, prop, {}, 'On', false, x, y, true)
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal expected, javascript
+
+    # Check Annotation : checked = false
+    opt = {'default_value' => 'default_value'}
+    eopt = {
+      'Subtype' => 'Widget',
+      'ap' => {
+        'n' => {
+         'Off' => 'q BT /F3 12.00 Tf 0 g 0 0 Td (8) Tj ET Q',
+         'On' => 'q BT /F3 12.00 Tf 0 g 0 0 Td (8) Tj ET Q'
+        }
+      },
+      'as' => 'Off',
+      'border' => [0, 0, 1],
+      'bs' => { 's' => 'I', 'w' => 1 },
+      'default_value' => 'default_value',
+      'da' => '/F3 12.00 Tf 0 g',
+      'f' => '0000_0100'.to_i(2),
+      'ft' => 'Btn',
+      'ff' => '0000_0000_0000_1100_0000_0000_0010'.gsub('_', '').to_i(2), # Radio, NoToggleToOff, required
+      'mk'=>{
+        'bc' => [128, 128, 128],
+        'bg' => [255, 255, 255],
+        'ca' =>  '(l)',
+        'if' => { 'a' => [0.5, 0.5] },
+      },
+    }
+
+    pdf = RBPDF.new
+    pdf.add_page
+    annots_obj_id = pdf.instance_variable_get('@annot_obj_id')
+    pdf.RadioButton(name, w, prop, opt, 'On', false, x, y) # js = false
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal '', javascript
+
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_equal 0,    page_annots[1][0]['numspaces']
+    assert_equal x,    page_annots[1][0]['x']
+    assert_equal y,    page_annots[1][0]['y']
+    assert_equal w,    page_annots[1][0]['w']
+    assert_equal w,    page_annots[1][0]['h']
+    assert_equal eopt, page_annots[1][0]['opt']
+    assert_equal name, page_annots[1][0]['txt']
+
+    radio_groups = pdf.instance_variable_get('@radio_groups')
+    assert_equal annots_obj_id + 1, radio_groups[0]
+
+    radiobutton_groups = pdf.instance_variable_get('@radiobutton_groups')
+    assert_equal 2,                 radiobutton_groups.length
+    assert_equal annots_obj_id + 2, radiobutton_groups[1][name][0]['kid']
+    assert_equal 'Off',             radiobutton_groups[1][name][0]['def']
+
+    # Check Annotation : checked = true
+    eopt['as'] = 'On'
+    eopt['v'] = ['/On']
+
+    pdf = RBPDF.new
+    pdf.add_page
+    annots_obj_id = pdf.instance_variable_get('@annot_obj_id')
+    pdf.RadioButton(name, w, prop, opt, 'On', true, x, y) # js = false
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal '', javascript
+
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_equal 0,    page_annots[1][0]['numspaces']
+    assert_equal x,    page_annots[1][0]['x']
+    assert_equal y,    page_annots[1][0]['y']
+    assert_equal w,    page_annots[1][0]['w']
+    assert_equal w,    page_annots[1][0]['h']
+    assert_equal eopt, page_annots[1][0]['opt']
+    assert_equal name, page_annots[1][0]['txt']
+
+    radiobutton_groups = pdf.instance_variable_get('@radiobutton_groups')
+    assert_equal 2,                 radiobutton_groups.length
+    assert_equal annots_obj_id + 2, radiobutton_groups[1][name][0]['kid']
+    assert_equal 'On',              radiobutton_groups[1][name][0]['def']
+  end
+
+  def eopt_result_Ch(name, values, ff)
+    {
+      'Subtype' => 'Widget',
+      'ap' => { 'n' => 'q BT /F1 12.00 Tf 0 g ET Q' },
+      'border' => [0, 0, 1],
+      'bs' => { 's' => 'S', 'w' => 1 },
+      'default_value' => 'default_value',
+      'da' => '/F1 12.00 Tf 0 g',
+      'f' => '0000_0100'.to_i(2),
+      'ft' => 'Ch',
+      'ff' => ff,
+      'mk'=>{
+        'bc' => [128, 128, 128],
+        'bg' => [255, 255, 255],
+        'if' => { 'a' => [0.5, 0.5] },
+      },
+      "opt" => values,
+      't' => name,
+    }
+  end
+
+  test "ListBox test" do
+    # Check javascript : Each element of an array that can be converted to a string.
+    pdf = RBPDF.new
+    pdf.add_page
+    name = 'list'
+    x = 50
+    y = 60
+    w = 40
+    h = 10
+    values = ['option1', "opti'on2", 'option3']
+    prop = {'required' => 'true', 'maxlength' => 10}
+
+    expected = addfield_result('listbox', name, x, y, w, h, pdf)
+    expected << "f#{name}.required='true';\n"
+    expected << "f#{name}.maxlength='10';\n}"
+    expected << "f#{name}.setItems(['option1','opti\'on2','option3']);\n"
+
+    result = pdf.ListBox(name, w, h, values, prop, {}, x, y, true )
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal expected, javascript
+
+    # Check javascript : Each element of an array that is an array.
+    pdf = RBPDF.new
+    pdf.add_page
+    values = [['', '-'], ['M', 'Male'],['F', "Fema'le"]]
+
+    expected = addfield_result('listbox', name, x, y, w, h, pdf)
+    expected << "f#{name}.required='true';\n"
+    expected << "f#{name}.maxlength='10';\n}"
+    expected << "f#{name}.setItems([['','-'],['M','Male'],['F','Fema\'le']]);\n"
+
+    result = pdf.ListBox(name, w, h, values, prop, {}, x, y, true )
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal expected, javascript
+
+    # Check Annotation
+    pdf = RBPDF.new
+    opt = {'default_value' => 'default_value'}
+    ff =  '0000_0000_0000_0000_0000_0000_0010'.gsub('_', '').to_i(2) # required
+    eopt = eopt_result_Ch(name, values, ff)
+
+    result = pdf.ListBox(name, w, h, values, prop, opt, x, y) # js = false
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal '', javascript
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_equal 0,    page_annots[1][0]['numspaces']
+    assert_equal x,    page_annots[1][0]['x']
+    assert_equal y,    page_annots[1][0]['y']
+    assert_equal w,    page_annots[1][0]['w']
+    assert_equal h,    page_annots[1][0]['h']
+    assert_equal eopt, page_annots[1][0]['opt']
+    assert_equal name, page_annots[1][0]['txt']
+  end
+
+  test "ComboBox test" do
+    # Check javascript : Each element of an array that can be converted to a string.
+    pdf = RBPDF.new
+    pdf.add_page
+    name = 'combo'
+    x = 50
+    y = 60
+    w = 40
+    h = 10
+    values = ['option1', "opti'on2", 'option3']
+    prop = {'required' => 'true', 'maxlength' => 10}
+
+    expected = addfield_result('combobox', name, x, y, w, h, pdf)
+    expected << "f#{name}.required='true';\n"
+    expected << "f#{name}.maxlength='10';\n}"
+    expected << "f#{name}.setItems(['option1','opti\'on2','option3']);\n"
+
+    result = pdf.ComboBox(name, w, h, values, prop, {}, x, y, true )
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal expected, javascript
+
+    # Check javascript : Each element of an array that is an array.
+    pdf = RBPDF.new
+    values = [['', '-'], ['M', 'Male'],['F', "Fema'le"]]
+
+    expected = addfield_result('combobox', name, x, y, w, h, pdf)
+    expected << "f#{name}.required='true';\n"
+    expected << "f#{name}.maxlength='10';\n}"
+    expected << "f#{name}.setItems([['','-'],['M','Male'],['F','Fema\'le']]);\n"
+
+    result = pdf.ComboBox(name, w, h, values, prop, {}, x, y, true )
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal expected, javascript
+
+    # Check Annotation
+    pdf = RBPDF.new
+    opt = {'default_value' => 'default_value'}
+    ff = '0000_0000_0010_0000_0000_0000_0010'.gsub('_', '').to_i(2) # Combo, required
+    eopt = eopt_result_Ch(name, values, ff)
+
+    result = pdf.ComboBox(name, w, h, values, prop, opt, x, y) # js = false
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal '', javascript
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_equal 0,    page_annots[1][0]['numspaces']
+    assert_equal x,    page_annots[1][0]['x']
+    assert_equal y,    page_annots[1][0]['y']
+    assert_equal w,    page_annots[1][0]['w']
+    assert_equal h,    page_annots[1][0]['h']
+    assert_equal eopt, page_annots[1][0]['opt']
+    assert_equal name, page_annots[1][0]['txt']
+  end
+
+  test "CheckBox test" do
+    # Check javascript
+    pdf = RBPDF.new
+    pdf.add_page
+    name = 'check'
+    x = 50
+    y = 50
+    w = 100
+    h = 50
+    onvalue = 'Yes'
+    prop = {'required' => 'true', 'maxlength' => 10}
+
+    expected = addfield_result('checkbox', name, x, y, w, w, pdf)
+    expected << "f#{name}.required='true';\n"
+    expected << "f#{name}.maxlength='10';\n}"
+
+    pdf.CheckBox(name, w, false, prop, {}, onvalue, x, y, true)
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal expected, javascript
+
+    # Check Annotation : checked = false
+    opt = {'default_value' => 'default_value'}
+    eopt = {
+      'Subtype' => 'Widget',
+      'ap' => {
+        'n' => {
+         'Off' => 'q BT /F3 12.00 Tf 0 g 0 0 Td (8) Tj ET Q',
+         'Yes' => 'q BT /F3 12.00 Tf 0 g 0 0 Td (8) Tj ET Q'
+        }
+      },
+      'as' => 'Off',
+      'border' => [0, 0, 1],
+      'bs' => { 's' => 'I', 'w' => 1 },
+      'default_value' => 'default_value',
+      'da' => '/F3 12.00 Tf 0 g',
+      'f' => '0000_0100'.to_i(2),
+      'ft' => 'Btn',
+      'ff' => '0000_0000_0000_0000_0000_0000_0010'.gsub('_', '').to_i(2), # required
+      'mk'=>{
+        'bc' => [128, 128, 128],
+        'bg' => [255, 255, 255],
+        'if' => { 'a' => [0.5, 0.5] },
+      },
+      'opt' => [onvalue],
+      't' => name,
+      'v' => ['/Off'],
+    }
+
+    pdf = RBPDF.new
+    pdf.add_page
+    pdf.CheckBox(name, w, false, prop, opt, onvalue, x, y) # js = false
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal '', javascript
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_equal 0,    page_annots[1][0]['numspaces']
+    assert_equal x,    page_annots[1][0]['x']
+    assert_equal y,    page_annots[1][0]['y']
+    assert_equal w,    page_annots[1][0]['w']
+    assert_equal w,    page_annots[1][0]['h']
+    assert_equal eopt, page_annots[1][0]['opt']
+    assert_equal name, page_annots[1][0]['txt']
+
+    # Check Annotation : checked = true
+    onvalue = 'OK'
+    eopt['opt'] = [onvalue]
+    eopt['as'] = 'Yes'
+    eopt['v'] = ['/Yes']
+
+    pdf = RBPDF.new
+    pdf.add_page
+    pdf.CheckBox(name, w, true, prop, opt, onvalue, x, y)  # js = false
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal '', javascript
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_equal 0,    page_annots[1][0]['numspaces']
+    assert_equal x,    page_annots[1][0]['x']
+    assert_equal y,    page_annots[1][0]['y']
+    assert_equal w,    page_annots[1][0]['w']
+    assert_equal w,    page_annots[1][0]['h']
+    assert_equal eopt, page_annots[1][0]['opt']
+    assert_equal name, page_annots[1][0]['txt']
+  end
+
+  def eopt_result_Btn(pdf, caption, name, aa)
+    s = pdf.send(:textstring, caption)
+    {
+      'Subtype' => 'Widget',
+      'aa' => aa,
+      'ap' => { 'n' => 'q BT /F1 12.00 Tf 0 g ET Q' },
+      'border' => [0, 0, 1],
+      'bs' => { 's' => 'S', 'w' => 1 },
+      'default_value' => 'default_value',
+      'da' => '/F1 12.00 Tf 0 g',
+      'f' => '0000_0000'.to_i(2),
+      'ft' => 'Btn',
+      'ff' => '0000_0000_0001_0000_0000_0000_0010'.gsub('_', '').to_i(2), # Pushbutton, required
+      'h' => 'P',
+      'mk'=>{
+        'ac' => s,
+        'bc' => [128, 128, 128],
+        'bg' => [255, 255, 255],
+        'ca' => s,
+        'if' => { 'a' => [0.5, 0.5] },
+        'rc' => s,
+      },
+      't' => caption,
+      'v' => name,
+    }
+  end
+
+  test "Button test" do
+    # Check javascript
+    pdf = RBPDF.new
+    pdf.add_page
+    name = 'button'
+    caption = "Pr'int"
+    action = "Print('')"
+    x = 50
+    y = 50
+    w = 100
+    h = 50
+    prop = {'required' => 'true', 'maxlength' => 10}
+
+    expected = addfield_result('button', name, x, y, w, h, pdf)
+    expected << "f#{name}.required='true';\n"
+    expected << "f#{name}.maxlength='10';\n}"
+    expected << "f#{name}.buttonSetCaption('#{caption}');\n"
+    expected << "f#{name}.setAction('MouseUp','#{action}');\n"
+    expected << "f#{name}.highlight='push';\n"
+    expected << "f#{name}.print=false;\n"
+
+    pdf.Button(name, w, h, caption, action, prop, {}, x, y, true)
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal expected, javascript
+
+    # Check Annotation : Print
+    opt = {'default_value' => 'default_value'}
+    eopt = eopt_result_Btn(pdf, caption, name, '/D 300001 0 R')
+
+    pdf = RBPDF.new
+    pdf.add_page
+    pdf.Button(name, w, h, caption, action, prop, opt, x, y) # js = false
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal '', javascript
+
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_equal 0,    page_annots[1][0]['numspaces']
+    assert_equal x,    page_annots[1][0]['x']
+    assert_equal y,    page_annots[1][0]['y']
+    assert_equal w,    page_annots[1][0]['w']
+    assert_equal h,    page_annots[1][0]['h']
+    assert_equal eopt, page_annots[1][0]['opt']
+    assert_equal name, page_annots[1][0]['txt']
+
+    js_objects = pdf.instance_variable_get('@js_objects')
+    assert_equal true, js_objects.value?({"js"=>"Print('')", "onload"=>false})
+
+    # Check Annotation : action : S
+    caption = 'Reset'
+    action = {'S'=>'ResetForm'}
+    eopt = eopt_result_Btn(pdf, caption, name, "/D << /S /ResetForm >>")
+
+    pdf = RBPDF.new
+    pdf.add_page
+    pdf.Button(name, w, h, caption, action, prop, opt, x, y) # js = false
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal '', javascript
+
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_equal 0,    page_annots[1][0]['numspaces']
+    assert_equal x,    page_annots[1][0]['x']
+    assert_equal y,    page_annots[1][0]['y']
+    assert_equal w,    page_annots[1][0]['w']
+    assert_equal h,    page_annots[1][0]['h']
+    assert_equal eopt, page_annots[1][0]['opt']
+    assert_equal name, page_annots[1][0]['txt']
+
+    # Check Annotation : action : Flags
+    caption = 'Flags'
+    action = {'Flags'=>
+      ['Include/Exclude', 'IncludeNoValueFields', 'ExportFormat', 'GetMethod', 'SubmitCoordinates',
+       'XFDF', 'IncludeAppendSaves', 'IncludeAnnotations', 'SubmitPDF', 'CanonicalFormat',
+       'ExclNonUserAnnots', 'ExclFKey', 'EmbedForm']}
+    eopt = eopt_result_Btn(pdf, caption, name, w, "/D << /Flags #{'0010_1111_1111_1111'.gsub('_', '').to_i(2)} >>")
+
+    pdf = RBPDF.new
+    pdf.add_page
+    pdf.Button(name, w, h, caption, action, prop, opt, x, y) # js = false
+    javascript = pdf.instance_variable_get('@javascript')
+    assert_equal '', javascript
+
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_equal 0,    page_annots[1][0]['numspaces']
+    assert_equal x,    page_annots[1][0]['x']
+    assert_equal y,    page_annots[1][0]['y']
+    assert_equal w,    page_annots[1][0]['w']
+    assert_equal h,    page_annots[1][0]['h']
+    assert_equal eopt, page_annots[1][0]['opt']
+    assert_equal name, page_annots[1][0]['txt']
+  end
+end

--- a/test/rbpdf_html_form_test.rb
+++ b/test/rbpdf_html_form_test.rb
@@ -1,0 +1,192 @@
+# coding: ASCII-8BIT
+#
+# Copyright (c) 2011-2023 NAITOH Jun
+# Released under the MIT license
+# http://www.opensource.org/licenses/MIT
+
+require 'test_helper'
+
+class RbpdfHtmlFormTest < Test::Unit::TestCase
+  test "write_html <form>,<input> tag test" do
+    pdf = RBPDF.new
+    pdf.set_print_header(false)
+    pdf.add_page()
+
+    htmlcontent = '<form method="post" action="http://localhost/printvars" enctype="multipart/form-data">
+    <label for="name">name:</label> <input type="text" name="name" value="test@example.net" size="20" maxlength="30" />
+    <label for="password">password:</label> <input type="password" name="password" value="" size="20" maxlength="30" />
+    <label for="infile">file:</label> <input type="file" name="userfile" size="20" />
+    <input type="submit" name="submit" value="Submit" />
+    <input type="reset" name="reset" value="Reset" />
+    <input type="button" name="print" value="Print" onclick="print()" />
+    <input type="hidden" name="hiddenfield" value="OK" />
+    </form>'
+
+    pdf.write_html(htmlcontent, true, 0, true, 0)
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 8,    page_annots[1].length
+
+    assert_not_equal nil, page_annots[1][0]['opt']
+    assert_equal 0, page_annots[1][0]['opt']['ff']
+    assert_equal 'Tx', page_annots[1][0]['opt']['ft']
+    assert_equal 4, page_annots[1][0]['opt']['f']
+    assert_equal 30, page_annots[1][0]['opt']['maxlen']
+    assert_equal 'name', page_annots[1][0]['opt']['t']
+    assert_equal 'test@example.net', page_annots[1][0]['opt']['v']
+    assert_equal "name", page_annots[1][0]['txt']
+
+    assert_not_equal nil, page_annots[1][1]['opt']
+    assert_equal '0000_0000_0000_0010_0000_0000_0000'.gsub('_', '').to_i(2), page_annots[1][1]['opt']['ff'] # password
+    assert_equal 'Tx', page_annots[1][1]['opt']['ft']
+    assert_equal 4, page_annots[1][1]['opt']['f']
+    assert_equal 'password', page_annots[1][1]['opt']['t']
+    assert_equal "password", page_annots[1][1]['txt']
+
+    assert_not_equal nil, page_annots[1][2]['opt']
+    assert_equal '0000_0001_0000_0000_0000_0000_0000'.gsub('_', '').to_i(2), page_annots[1][2]['opt']['ff'] # fileSelect
+    assert_equal 'Tx', page_annots[1][2]['opt']['ft']
+    assert_equal 4, page_annots[1][2]['opt']['f']
+    assert_equal 'userfile', page_annots[1][2]['opt']['t']
+    assert_equal "userfile", page_annots[1][2]['txt']
+
+    assert_not_equal nil, page_annots[1][3]['opt']
+    assert_equal '0000_0000_0001_0000_0000_0000_0000'.gsub('_', '').to_i(2), page_annots[1][3]['opt']['ff'] # Pushbutton
+    assert_equal 'Btn', page_annots[1][3]['opt']['ft']
+    assert_equal 0, page_annots[1][3]['opt']['f']
+    assert_equal '*', page_annots[1][3]['opt']['t']
+    assert_equal "FB_userfile", page_annots[1][3]['txt']
+
+    assert_not_equal nil, page_annots[1][4]['opt']
+    assert_equal '0000_0000_0001_0000_0000_0000_0000'.gsub('_', '').to_i(2), page_annots[1][4]['opt']['ff'] # Pushbutton
+    assert_equal 'Btn', page_annots[1][4]['opt']['ft']
+    assert_equal 0, page_annots[1][4]['opt']['f']
+    assert_equal 'Submit', page_annots[1][4]['opt']['t']
+    assert_equal "submit", page_annots[1][4]['txt']
+    assert_equal '/D << /S /SubmitForm /F (http://localhost/printvars) /Flags 4 >>', page_annots[1][4]['opt']['aa']
+
+    assert_not_equal nil, page_annots[1][5]['opt']
+    assert_equal '0000_0000_0001_0000_0000_0000_0000'.gsub('_', '').to_i(2), page_annots[1][5]['opt']['ff'] # Pushbutton
+    assert_equal 'Btn', page_annots[1][5]['opt']['ft']
+    assert_equal 0, page_annots[1][5]['opt']['f']
+    assert_equal 'Reset', page_annots[1][5]['opt']['t']
+    assert_equal 'B', page_annots[1][5]['opt']['bs']['s']
+    assert_equal "reset", page_annots[1][5]['txt']
+    assert_equal '/D << /S /ResetForm >>', page_annots[1][5]['opt']['aa']
+
+    assert_not_equal nil, page_annots[1][6]['opt']
+    assert_equal '0000_0000_0001_0000_0000_0000_0000'.gsub('_', '').to_i(2), page_annots[1][6]['opt']['ff'] # Pushbutton
+    assert_equal 'Btn', page_annots[1][6]['opt']['ft']
+    assert_equal 0, page_annots[1][6]['opt']['f']
+    assert_equal 'Print', page_annots[1][6]['opt']['t']
+    assert_equal "print", page_annots[1][6]['txt']
+    js_objects = pdf.instance_variable_get('@js_objects')
+    assert_equal true, js_objects.value?({"js"=>"print()", "onload"=>false})
+
+    assert_not_equal nil, page_annots[1][7]['opt']
+    assert_equal 0, page_annots[1][7]['opt']['ff']
+    assert_equal 'Tx', page_annots[1][7]['opt']['ft']
+    assert_equal ['invisible', 'hidden'], page_annots[1][7]['opt']['f']
+    assert_equal 'hiddenfield', page_annots[1][7]['opt']['t']
+    assert_equal "hiddenfield", page_annots[1][7]['txt']
+  end
+
+  test "write_html <select> tag ComboBox test" do
+    pdf = RBPDF.new
+    pdf.set_print_header(false)
+    pdf.add_page()
+
+    htmlcontent = '<select name="selection" size="0">
+    <option value="0">zero</option>
+    <option value="1">one</option>
+    </select>'
+
+    pdf.write_html(htmlcontent, true, 0, true, 0)
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_not_equal nil, page_annots[1][0]['opt']
+    assert_equal '0000_0000_0010_0000_0000_0000_0000'.gsub('_', '').to_i(2), page_annots[1][0]['opt']['ff'] # Combo
+    assert_equal 'Ch', page_annots[1][0]['opt']['ft']
+    assert_equal 'selection', page_annots[1][0]['opt']['t']
+    assert_equal "selection", page_annots[1][0]['txt']
+  end
+
+  test "write_html <select multiple='multiple'> tag ListBox test" do
+    pdf = RBPDF.new
+    pdf.set_print_header(false)
+    pdf.add_page()
+
+    htmlcontent = '<select name="multiselection" size="2" multiple="multiple">
+    <option value="0">zero</option>
+    <option value="1">one</option>
+    </select>'
+
+    pdf.write_html(htmlcontent, true, 0, true, 0)
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 1,    page_annots[1].length
+    assert_not_equal nil, page_annots[1][0]['opt']
+    assert_equal '0000_0010_0000_0000_0000_0000_0000'.gsub('_', '').to_i(2), page_annots[1][0]['opt']['ff'] # multipleSelection
+    assert_equal 'Ch', page_annots[1][0]['opt']['ft']
+    assert_equal 'multiselection', page_annots[1][0]['opt']['t']
+    assert_equal "multiselection", page_annots[1][0]['txt']
+  end
+
+  test "write_html <input type='checkbox'> tag test" do
+    pdf = RBPDF.new
+    pdf.set_print_header(false)
+    pdf.add_page()
+
+    htmlcontent = '<input type="checkbox" name="agree" value="1" checked="checked" />
+                   <input type="checkbox" name="no agree" value="1" disabled/>'
+    pdf.write_html(htmlcontent, true, 0, true, 0)
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 2,    page_annots[1].length
+    assert_not_equal nil, page_annots[1][0]['opt']
+    assert_equal 0, page_annots[1][0]['opt']['ff']
+    assert_equal 'Btn', page_annots[1][0]['opt']['ft']
+    assert_equal 'Yes', page_annots[1][0]['opt']['as']
+    assert_equal ['/Yes'], page_annots[1][0]['opt']['v']
+    assert_equal 'agree', page_annots[1][0]['opt']['t']
+    assert_equal 'agree', page_annots[1][0]['txt']
+
+    assert_not_equal nil, page_annots[1][1]['opt']
+    assert_equal '0000_0000_0000_0000_0000_0000_0001'.gsub('_', '').to_i(2), page_annots[1][1]['opt']['ff']
+    assert_equal 'Btn', page_annots[1][1]['opt']['ft']
+    assert_equal 'Off', page_annots[1][1]['opt']['as']
+    assert_equal ['/Off'], page_annots[1][1]['opt']['v']
+    assert_equal 'no agree', page_annots[1][1]['opt']['t']
+    assert_equal 'no agree', page_annots[1][1]['txt']
+  end
+
+  test "write_html <input type='radio'> tag test" do
+    pdf = RBPDF.new
+    pdf.set_print_header(false)
+    pdf.add_page()
+
+    htmlcontent = '<input type="radio" name="radioquestion" id="rqa" value="1" /> <label for="rqa">one</label>
+    <input type="radio" name="radioquestion" id="rqb" value="2" checked="checked"/> <label for="rqb">two</label>'
+
+    pdf.write_html(htmlcontent, true, 0, true, 0)
+    page_annots = pdf.instance_variable_get('@page_annots')
+    assert_equal 2,    page_annots.length
+    assert_equal nil,  page_annots[0]
+    assert_equal 2,    page_annots[1].length
+    assert_not_equal nil, page_annots[1][0]['opt']
+    assert_equal '0000_0000_0000_1100_0000_0000_0000'.gsub('_', '').to_i(2), page_annots[1][0]['opt']['ff'] # Radio, NoToggleToOff
+    assert_equal 'Btn', page_annots[1][0]['opt']['ft']
+    assert_equal 'Off', page_annots[1][0]['opt']['as']
+    assert_equal 'radioquestion', page_annots[1][0]['txt']
+    assert_not_equal nil, page_annots[1][1]['opt']
+    assert_equal '0000_0000_0000_1100_0000_0000_0000'.gsub('_', '').to_i(2), page_annots[1][1]['opt']['ff'] # Radio, NoToggleToOff
+    assert_equal 'Btn', page_annots[1][1]['opt']['ft']
+    assert_equal '2', page_annots[1][1]['opt']['as']
+    assert_equal 'radioquestion', page_annots[1][1]['txt']
+  end
+end

--- a/test/rbpdf_html_test.rb
+++ b/test/rbpdf_html_test.rb
@@ -582,6 +582,36 @@ class RbpdfHtmlTest < Test::Unit::TestCase
     assert_equal 'a\\\\bc', pdf_text
   end
 
+  test "write_html <ul><li> tag test" do
+    pdf = MYPDF.new
+    pdf.set_print_header(false)
+    pdf.add_page()
+
+    htmlcontent = '<ul><li>text A</li><li>text B</li></ul>'
+    pdf.write_html(htmlcontent, true, 0, true, 0)
+    pdf_text = pdf.get_html_text(1)
+    assert_equal 'text Atext B', pdf_text
+  end
+
+  test "write_html <ul><li><input> tag test" do
+    pdf = MYPDF.new
+    pdf.set_print_header(false)
+    pdf.add_page()
+
+    htmlcontent = '
+    <ul>
+      <li><input type="checkbox">bar
+        <ul>
+          <li><input type="checkbox">baz</li>
+        </ul>
+      </li>
+      <li>test</li>
+    </ul>'
+    pdf.write_html(htmlcontent, true, 0, true, 0)
+    pdf_text = pdf.get_html_text(1)
+    assert_equal 'barbaztest', pdf_text
+  end
+
   test "write_html <ol><li> tag test" do
     pdf = MYPDF.new
     pdf.set_print_header(false)


### PR DESCRIPTION
- Some support for Forms fields (see example n. 14).
- Some support for XHTML forms (see example n. 54).
- addJavascriptObject() method was added.
- HTML tag Boolean Attribute supported.
- Support GitHub Flavored Markdown Task list items (extension)

|  PDF Viewer  |  checked (no disabled) | no checked (no disabled) | checked (disabled) | no checked (disabled) |
| ---- | ---- | ---- | ---- | ---- |
|  Acrobat Reader 2023.001.20177   |  ✅ 🙆‍♂️   | ■ 🙆‍♂️   | ☑️ 🙆‍♂️ |  □ 🙆‍♂️ |
|  Chrome 114  |    ✅ 🙆‍♂️   |  ■ 🙆‍♂️   |  ☑️ 🙆‍♂️  |  □ 🙆‍♂️  |
|  Firefox 115 |    ✅ 🙆‍♂️   | ■ 🙆‍♂️ |  ☑️ 🙆‍♂️   | 🙅 (not displayed) |
|  macOS 13.3 PDF Preview | ✅ 🙆‍♂️   | ■ 🙆‍♂️    |  ✅ 🙅 (editable) | ■ 🙅 (editable)  |

※ disabled = not editable

### FYI:

- getAnnotOptFromJSProp
  See:
    - prop(javascript field properties) : https://opensource.adobe.com/dc-acrobat-sdk-docs/library/jsapiref/JS_API_AcroJS.html
    - /Ff : https://www.pdf-tools.trustss.co.jp/Syntax/form.html
- AcroForm
  See:  https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf
- Button : Flags for submit-form actions
  See: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf
- putannotsobjs : Annotation Flags
  See:
    - https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf
    - https://www.pdf-tools.trustss.co.jp/Syntax/annot.html#f_entry