### PR TITLE
Resolving infinite loops when `rtl == true`

### DIFF
--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -12960,7 +12960,7 @@ public
           if !@premode
             prelen = dom[key]['value'].length
             if isRTLTextDir()
-              dom[key]['value'] = dom[key]['value'].rstrip + 0.chr
+              dom[key]['value'] = dom[key]['value'].rstrip
             else
               dom[key]['value'] = dom[key]['value'].lstrip
             end

--- a/test/rbpdf_htmlcell_test.rb
+++ b/test/rbpdf_htmlcell_test.rb
@@ -61,4 +61,19 @@ class RbpdfTest < Test::Unit::TestCase
     no = pdf.get_num_pages
     assert_equal data[:no], no
   end
+
+  htmls = {
+    'rtl=false' => {html: '<p><img src="/dummy.png" style="width:2000px;height:563px;"></p>', rtl: false},
+    'rtl=true' => {html: '<p><img src="/dummy.png" style="width:2000px;height:563px;"></p>', rtl: true},
+  }
+
+  data(htmls)
+  test "write_html_cell Infinit loop check test with image size" do |data|
+    pdf = RBPDF.new
+    pdf.add_page()
+    pdf.set_rtl(data[:rtl])
+    pdf.write_html_cell(0, 0, '', '', data[:html])
+    no = pdf.get_num_pages
+    assert_equal 1, no
+  end
 end


### PR DESCRIPTION
https://github.com/naitoh/rbpdf/blob/f1b16a0e7b4c3e19bde51174840a76d4fba2ef80/lib/rbpdf.rb#L12374-L12671

In the above, if `rtl == true`, `dom[key]['value'] == 0x00`, so `dom[key]['value'].length => 1` and `@newline = false`.

If `@newline = false`, the following branch is entered again, resulting in an infinite loop.

https://github.com/naitoh/rbpdf/blob/f1b16a0e7b4c3e19bde51174840a76d4fba2ef80/lib/rbpdf.rb#L12203-L12217

I implemented `0.chr` in https://github.com/naitoh/rbpdf/commit/f2c82d07a585e9ef8d43619e1b0cc4c3353354ec , but since it is a meaningless process and `rtl == true/false` produces different results Delete it.

fixed https://github.com/naitoh/rbpdf/issues/88