### PR TITLE
Optimize whitespace presevation

### DIFF
--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -11983,7 +11983,7 @@ public
     # Escape '<' character for not tag case.
     html = html.gsub(%r{(<+)([^/a-zA-Z])}){CGI.escapeHTML($1) + $2}.gsub(%r{</([^a-zA-Z])}){'&lt;/' +  $1}
 
-    html = "%s" % sanitize(html, :tags=> %w(a b blockquote body br dd del div dl dt em font h1 h2 h3 h4 h5 h6 hr i img li ol p pre small span strong sub sup table td th thead tr tt u ins ul), :attributes => %w(cellspacing cellpadding bgcolor color value width height src size colspan rowspan style align border face href name dir class id nobr stroke strokecolor fill nested tablehead))
+    html = "%s" % sanitize(html, :tags=> %w(a b blockquote body br code dd del div dl dt em font h1 h2 h3 h4 h5 h6 hr i img li ol p pre small span strong sub sup table td th thead tr tt u ins ul), :attributes => %w(cellspacing cellpadding bgcolor color value width height src size colspan rowspan style align border face href name dir class id nobr stroke strokecolor fill nested tablehead))
   end
   protected :sanitize_html
 

--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -11375,6 +11375,8 @@ protected
         # preserve whitespace on <pre> tag
         html_b = html_b.gsub(/<xre([^\>]*)>(.*?)[\s](.*?)<\/pre>/mi, "<xre\\1>\\2&nbsp;\\3</pre>")
       end
+      # keep nbsp; just for multi-whitespace case or single whitespace indentation case
+      html_b = html_b.gsub(/(?<=.)(?<!&nbsp;| |>)&nbsp;(?!&nbsp;| )/, " ")
       html = html_a + html_b + html[(pos + 6)..-1]
       offset = (html_a + html_b).length
     end


### PR DESCRIPTION
Hello,

I replaced the white spaces where there was only one but not in the case of an indentation which avoids possible line breaks after a tag.

(I work on colorization code (rouge) in redmine PDF export)

Thks