### PR TITLE
mini_magick v5.0 supoort and marcel gem added

### DIFF
--- a/Gemfile.rails5_mini_magick
+++ b/Gemfile.rails5_mini_magick
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2023 NAITOH Jun
+# Copyright (c) 2011-2025 NAITOH Jun
 # Released under the MIT license
 # http://www.opensource.org/licenses/MIT
 
@@ -8,5 +8,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem "actionpack", "~> 5.2.8.1"
-gem "mini_magick", "< 5.0"
+gem "mini_magick"
+gem 'marcel'
 gem 'loofah', '<= 2.20.0' if RUBY_VERSION < '2.5'

--- a/Gemfile.rails6_mini_magick
+++ b/Gemfile.rails6_mini_magick
@@ -9,4 +9,5 @@ gemspec
 
 gem "actionpack", "~> 6.1.7.2"
 gem "concurrent-ruby", '1.3.4'
-gem "mini_magick", "< 5.0"
+gem "mini_magick"
+gem 'marcel'

--- a/Gemfile.rails7_mini_magick
+++ b/Gemfile.rails7_mini_magick
@@ -8,4 +8,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem "actionpack", "~> 7.2.2.1"
-gem "mini_magick", "< 5.0"
+gem "mini_magick"
+gem 'marcel'

--- a/Gemfile.rails8_mini_magick
+++ b/Gemfile.rails8_mini_magick
@@ -8,5 +8,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem "actionpack", "~> 8.0.2"
-gem "mini_magick", "< 5.0"
-
+gem "mini_magick"
+gem 'marcel'

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ RBPDF is distributed via RubyGems, and can be installed the usual way that you i
 
 If you are using image file, it is recommended you install:
 ```
-gem install mini_magick
+gem install mini_magick marcel
 ```
 or
 ```

--- a/lib/core/mini_magick.rb
+++ b/lib/core/mini_magick.rb
@@ -51,18 +51,27 @@ module Rbpdf
       return false
     end
 
+    unless Object.const_defined?(:Marcel)
+      Error('No Marcel: Non-PNG file is not supported.: ' + filename);
+      return false
+    end
+
     image = MiniMagick::Image.open(filename)
     
     width = image.width
     height = image.height
 
-    out['mime'] = image.mime_type
+    mime_type = File.open filename do |file|
+      ::Marcel::MimeType.for file
+    end
+
+    out['mime'] = mime_type
     out[0] = width
     out[1] = height
     
     # These are actually meant to return integer values But I couldn't seem to find anything saying what those values are.
     # So for now they return strings. The only place that uses this at the moment is the parsejpeg method, so I've changed that too.
-    case image.mime_type
+    case mime_type
     when "image/gif"
       out[2] = "GIF"
     when "image/jpeg"

--- a/lib/rbpdf.rb
+++ b/lib/rbpdf.rb
@@ -59,6 +59,12 @@ rescue LoadError
   # MiniMagick is not available
 end
 
+begin
+  require 'marcel' unless Object.const_defined?(:Marcel)
+rescue LoadError
+  # Marcel is not available
+end
+
 unless Object.const_defined?(:MiniMagick)
   begin
     # RMagick 2.14.0


### PR DESCRIPTION
## Why?
fixes #102

https://github.com/minimagick/minimagick/releases/tag/v5.0.0
> Removed deprecated Image#mime_type, as it wasn't accurate.
> MIME type from file content should be determined either using Marcel or MimeMagic, or mime-types or MiniMime using Image#type.

```
[MiniMagick] MiniMagick::Image#mime_type has been deprecated, because it wasn't returning correct result for all formats ImageMagick supports. Unfortunately, returning the correct MIME type would be very slow, because it would require ImageMagick to read the whole file. It's better to use Marcel and MimeMagic gems, which are able to determine the MIME type just from the image header.
```